### PR TITLE
Fixes #29 - One Google Cloud Platform for Eclipse Mars target

### DIFF
--- a/.project
+++ b/.project
@@ -14,4 +14,42 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1459454994333</id>
+			<name></name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-plugins</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1459454994335</id>
+			<name></name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-eclipse</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1459454994338</id>
+			<name></name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-features</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1459454994340</id>
+			<name></name>
+			<type>26</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-gcp-repo</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
Added `features`, `plugins`, `eclipse` to resource filter on parent project