### PR TITLE
Setup target platforms for Mars and Neon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ sudo: false
 language: java
 jdk:
   - openjdk7
+script:
+  - mvn verify
+  - mvn -Declipse.target=neon verify
 cache:  
-  directories:  
-   - $HOME/.m2  
+  directories:
+   - $HOME/.m2
 

--- a/eclipse/mars/gcp-eclipse-mars.target
+++ b/eclipse/mars/gcp-eclipse-mars.target
@@ -1,23 +1,34 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
-<target name="Google Cloud Platform for Eclipse Mars" sequenceNumber="1">
+<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
+<target name="GCP for Eclipse Mars" sequenceNumber="1459478600">
   <locations>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" 
-              includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sdk.feature.group" version="4.5.1.v20150904-0345"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.11.1.v20150904-0015"/>
-      <unit id="org.eclipse.jst.server_ui.feature.feature.group" version="3.4.200.v201512031711"/>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
+      <repository location="http://download.eclipse.org/cbi/updates/license"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.sdk.feature.group" version="4.5.2.v20160212-1500"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.11.2.v20160212-1500"/>
       <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.2.20150902-0002"/>
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.2.1.20150819-2220"/>
-      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.17.0.v20150828-2041"/>
-      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.7.1.v201509022125"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.4.2.v201505291546"/>
+      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.18.0.v20151116-1930"/>
+      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.4.2.v201512181609"/>
       <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.12.0.v201406061321-7PB21FEpPZQXdcX0z-_yMM0Hfz0w"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
       <unit id="org.eclipse.jetty.http" version="9.2.13.v20150730"/>
       <unit id="org.eclipse.jetty.servlet" version="9.2.13.v20150730"/>
       <unit id="org.eclipse.jetty.server" version="9.2.13.v20150730"/>
       <unit id="org.eclipse.jetty.util" version="9.2.13.v20150730"/>
       <repository location="http://download.eclipse.org/releases/mars/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.7.1.v201512021921"/>
+      <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.200.v201512031711"/>
+      <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.7.1.v201602111638"/>
+      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.500.v201508271522"/>
+      <repository location="http://download.eclipse.org/webtools/repository/mars/"/>
     </location>
   </locations>
 </target>

--- a/eclipse/mars/gcp-eclipse-mars.tpd
+++ b/eclipse/mars/gcp-eclipse-mars.tpd
@@ -1,0 +1,40 @@
+/* 
+ * Target Platform Definition created using Mikael Barbero's TPD editor 
+ * <https://github.com/mbarbero/fr.obeo.releng.targetplatform/>
+ * 
+ * If you make changes to this file, either:
+ * 
+ *    * Right-click in the editor and choose 'Create Target Definition File'
+ *      to update the corresponding .target file.
+ *    * Right-lick in the editor and choose 'Set as Target Platform'
+ *      to update your IDE's target platform (regenerates the .target too)
+ */
+target "GCP for Eclipse Mars" with source requirements
+
+location "http://download.eclipse.org/cbi/updates/license" {
+    org.eclipse.license.feature.group    
+}
+
+location "http://download.eclipse.org/releases/mars/" {
+	org.eclipse.sdk.feature.group
+	org.eclipse.jdt.feature.group
+	org.eclipse.m2e.feature.feature.group
+	org.eclipse.m2e.wtp.feature.feature.group
+	org.eclipse.mylyn.commons.feature.group
+	org.eclipse.jpt.jpa.feature.feature.group
+	org.eclipse.datatools.sdk.feature.feature.group
+	org.eclipse.swtbot.eclipse.feature.group
+	
+	org.eclipse.jetty.http
+	org.eclipse.jetty.servlet
+	org.eclipse.jetty.server
+	org.eclipse.jetty.util
+}
+
+location "http://download.eclipse.org/webtools/repository/mars/" {
+    org.eclipse.jst.web_sdk.feature.feature.group
+    org.eclipse.jst.server_sdk.feature.feature.group
+    org.eclipse.wst.common.fproj.sdk.feature.group
+    org.eclipse.wst.web_sdk.feature.feature.group
+    org.eclipse.wst.server_adapters.sdk.feature.feature.group
+}

--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde?>
+<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
+<target name="GCP for Eclipse Neon" sequenceNumber="1459481460">
+  <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
+      <repository location="http://download.eclipse.org/cbi/updates/license"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.sdk.feature.group" version="4.6.0.v20160317-0200"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.12.0.v20160317-0200"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20160321-2203"/>
+      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.0.20151111-2338"/>
+      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.19.0.v20160111-1919"/>
+      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201603181811"/>
+      <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
+      <unit id="org.eclipse.jetty.http" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.server" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.util" version="9.3.5.v20151012"/>
+      <repository location="http://download.eclipse.org/releases/neon"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201603172133"/>
+      <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201603031514"/>
+      <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.8.0.v201603232216"/>
+      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201603031514"/>
+      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.8.0/S-3.8.0M6-20160324010110/repository"/>
+    </location>
+  </locations>
+</target>

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -1,0 +1,42 @@
+/* 
+ * Target Platform Definition created using Mikael Barbero's TPD editor 
+ * <https://github.com/mbarbero/fr.obeo.releng.targetplatform/>
+ * 
+ * If you make changes to this file, either:
+ * 
+ *    * Right-click in the editor and choose 'Create Target Definition File'
+ *      to update the corresponding .target file.
+ *    * Right-lick in the editor and choose 'Set as Target Platform'
+ *      to update your IDE's target platform (regenerates the .target too)
+ */
+target "GCP for Eclipse Neon" with source requirements
+
+location "http://download.eclipse.org/cbi/updates/license" {
+    org.eclipse.license.feature.group    
+}
+
+location "http://download.eclipse.org/releases/neon" {
+	org.eclipse.sdk.feature.group
+	org.eclipse.jdt.feature.group
+	org.eclipse.m2e.feature.feature.group
+	org.eclipse.m2e.wtp.feature.feature.group
+	org.eclipse.mylyn.commons.feature.group
+	org.eclipse.jpt.jpa.feature.feature.group
+	org.eclipse.datatools.sdk.feature.feature.group
+	org.eclipse.swtbot.eclipse.feature.group
+	
+	org.eclipse.jetty.http
+	org.eclipse.jetty.servlet
+	org.eclipse.jetty.server
+	org.eclipse.jetty.util
+}
+
+// /webtools/repository/neon currently has some issues
+// location "http://download.eclipse.org/webtools/repository/neon/" {
+location "http://download.eclipse.org/webtools/downloads/drops/R3.8.0/S-3.8.0M6-20160324010110/repository" {
+    org.eclipse.jst.web_sdk.feature.feature.group
+    org.eclipse.jst.server_sdk.feature.feature.group
+    org.eclipse.wst.common.fproj.sdk.feature.group
+    org.eclipse.wst.web_sdk.feature.feature.group
+    org.eclipse.wst.server_adapters.sdk.feature.feature.group
+}

--- a/eclipse/neon/pom.xml
+++ b/eclipse/neon/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+ <parent>
+    <groupId>com.google.gcp.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>94.0.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <artifactId>gcp-eclipse-neon</artifactId>
+  <version>4.6.0-SNAPSHOT</version>
+  <packaging>eclipse-target-definition</packaging>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,16 +20,7 @@
     <tycho-extras.version>0.24.0</tycho-extras.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse.target>mars</eclipse.target>
-    <eclipse-repo.url>http://download.eclipse.org/releases/${eclipse.target}</eclipse-repo.url>
   </properties>
-
-  <repositories>
-    <repository>
-      <id>eclipse</id>
-      <url>${eclipse-repo.url}</url>
-      <layout>p2</layout>
-    </repository>
-  </repositories>
 
   <build>
     <plugins>
@@ -141,7 +132,7 @@
     <profile>
       <id>build-eclipse-mars</id>
       <activation>
-      <!-- Default target if no eclipse.target specified. -->
+        <!-- Default target if no eclipse.target specified. -->
         <property>
           <name>!eclipse.target</name>
           <!-- when no longer the default: <name>eclipse.target</name> <value>mars</value> -->
@@ -167,6 +158,41 @@
                 <groupId>com.google.gcp.eclipse</groupId>
                 <artifactId>gcp-eclipse-mars</artifactId>
                 <version>4.5.0-SNAPSHOT</version>
+              </artifact>
+            </target>
+           </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>build-eclipse-neon</id>
+      <activation>
+        <property>
+          <name>eclipse.target</name> <value>neon</value>
+        </property>
+      </activation>
+      <properties>
+         <jettyMinVersion>9.1</jettyMinVersion>
+         <jettyMaxVersion>9.3</jettyMaxVersion>
+      </properties>
+      <!-- build against a known target platform -->
+      <modules>
+        <module>eclipse/neon</module>
+      </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>target-platform-configuration</artifactId>
+            <version>${tycho.version}</version>
+            <configuration>
+            <target>
+              <artifact>
+                <groupId>com.google.gcp.eclipse</groupId>
+                <artifactId>gcp-eclipse-neon</artifactId>
+                <version>4.6.0-SNAPSHOT</version>
               </artifact>
             </target>
            </configuration>


### PR DESCRIPTION
- Update to Mars.2 and include WTP SDK features for source bundles
- Add Neon target; explicitly specify WTP Neon M6 repository as the general WTP Neon repository is not up-to-date
- Configure Travis to build against both Eclipse Mars and Neon