### PR TITLE
Add Travis profile, and allow Maven toolchains can be overridden

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: java
 jdk:
   - openjdk7
 script:
-  - mvn verify
-  - mvn -Declipse.target=neon verify
+  - mvn -Ptravis verify
+  - mvn -Ptravis -Declipse.target=neon verify
 cache:  
   directories:
    - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,13 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <eclipse.target>mars</eclipse.target>
+
+    <!--
+      `SYSTEM` means use the default JDK (necc for Travis). 
+      `BREE` means find a configured JDK using Maven Toolchains matching
+      the Bundle-RequiredExecutionEnvironment. See `README.md` for details.
+    -->
+    <tycho.toolchains>BREE</tycho.toolchains>
   </properties>
 
   <build>
@@ -116,7 +123,7 @@
           <version>${tycho.version}</version>
           <configuration>
             <showWarnings>true</showWarnings>
-            <useJDK>BREE</useJDK>
+            <useJDK>${tycho.toolchains}</useJDK>
           </configuration>
         </plugin>
 
@@ -201,6 +208,14 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>travis</id>
+      <properties>
+         <!-- We configure Travis to use jdk7 -->
+         <tycho.toolchains>SYSTEM</tycho.toolchains>
+      </properties>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Allow Travis to opt-out from the toolchains enforcement as its build is configured to always with with `jdk7`.  Uses a Travis profile in case we need to add more options later.