### PR TITLE
Ensure Travis doesn't pull stale artifacts from the cached repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ jdk:
   - openjdk7
 install: true
 script:
-  - mvn -Ptravis verify
+  - mvn -Ptravis --fail-at-end verify
   - jdk_switcher use oraclejdk8
-  - mvn -Ptravis verify -Declipse.target=neon
+  - mvn -Ptravis --fail-at-end verify -Declipse.target=neon
 cache:  
   directories:
    - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -215,8 +215,10 @@
     <profile>
       <id>travis</id>
       <properties>
-         <!-- We configure Travis to use jdk7 -->
-         <tycho.toolchains>SYSTEM</tycho.toolchains>
+        <!-- We configure Travis to use jdk7 -->
+        <tycho.toolchains>SYSTEM</tycho.toolchains>
+        <!-- Ensure we don't resolved mis-cached artifacts -->
+        <tycho.localArtifacts>ignore</tycho.localArtifacts>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Configure Tycho to ignore copies of build artifacts found in the local repository.  This should prevent Tycho from resolving missed references to renamed/deleted artifacts from Travis' cached repository.