### PR TITLE
Fix warnings in .test.dependencies as it has no source

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.test.dependencies;singleton:
 Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: Google, Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Bundle-ClassPath: .,
- lib/mockito-core-1.10.19.jar,
+Bundle-ClassPath: lib/mockito-core-1.10.19.jar,
  lib/objenesis-2.2.jar
 Export-Package: org.mockito;provider=google;version="1.10.19";mandatory:=provider,
  org.mockito.asm;provider=google;version="1.10.19";mandatory:=provider,

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
@@ -1,7 +1,4 @@
-source.. = .
-output.. = .
 bin.includes = META-INF/,\
-               .,\
                lib/mockito-core-1.10.19.jar,\
                lib/objenesis-2.2.jar
 javacSource=1.7


### PR DESCRIPTION
Trivial fix. PTAL @elharo 