### PR TITLE
Fix progress dialog flicker by reworking the project creation as a single workspace operation

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/StandardProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/StandardProjectWizard.java
@@ -1,7 +1,5 @@
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
-import java.lang.reflect.InvocationTargetException;
-
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -12,6 +10,8 @@ import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.ide.undo.WorkspaceUndoUtil;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class StandardProjectWizard extends Wizard implements INewWizard {
 
   private AppEngineStandardWizardPage page;
@@ -20,6 +20,7 @@ public class StandardProjectWizard extends Wizard implements INewWizard {
   public StandardProjectWizard() {
     this.setWindowTitle("New App Engine Standard Project");
     page = new AppEngineStandardWizardPage();
+    setNeedsProgressMonitor(true);
   }
   
   @Override 
@@ -49,7 +50,7 @@ public class StandardProjectWizard extends Wizard implements INewWizard {
 
     IStatus status = Status.OK_STATUS;
     try {
-      boolean fork = false;
+      boolean fork = true;
       boolean cancelable = true;
       getContainer().run(fork, cancelable, runnable);
     } catch (InterruptedException ex) {


### PR DESCRIPTION
Setting `fork=false` just means that most of the code is executed within the UI thread, and so progress monitoring never occurs until the operation has already completed.  This doesn't much matter for very short operations, but long operations will lead to the UI hanging.

The flicker happens for two reasons.  The first problem is that the `CreateProjectOperation` and the code in `CodeTemplates` are not executed as a single workspace operation (viz `IWorkspace#run()` and `IWorkspaceRunnable`).  The project creation triggers builder activity, as does each file- and folder-creation (when not run as a workspace operation). So each of the file creations in `CodeTeamplates` is blocked until any current operations complete (hence the _user operation is block_).  The second problem is that the `CreateAppEngineStandardWtpProject` is reusing the progress monitor which is unsupported.  The execution method needs to pass down sub-monitors to its child operations.

So the key is to ensure that the project creation and file materialization happens within a single workspace operation.  This fix causes the `CreateAppEngineStandardWtpProject ` to subclass from `WorkspaceModificationOperation`, which ensures the operation is executed as s single workspace operation.  It also fixes the handling of the `IProgressMonitor`. You can see it by putting a conditional breakpoint on SubMonitor#internalWorked() that just spins for a bit.