### PR TITLE
don't create project on top of existing directory

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardProjectConfigTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardProjectConfigTest.java
@@ -1,5 +1,8 @@
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -33,6 +36,12 @@ public class AppEngineStandardProjectConfigTest {
   public void testPackageName() {
     config.setPackageName("com.foo.bar");
     Assert.assertEquals("com.foo.bar", config.getPackageName());
+  }
+  
+  @Test
+  public void testEclipseProjectLocationUri() throws URISyntaxException {   
+    config.setEclipseProjectLocationUri(new URI("file://foo/bar"));   
+    Assert.assertEquals(new URI("file://foo/bar"), config.getEclipseProjectLocationUri());    
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardProjectConfig.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardProjectConfig.java
@@ -1,5 +1,7 @@
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
+import java.net.URI;
+
 import org.eclipse.core.resources.IProject;
 
 /**
@@ -7,6 +9,7 @@ import org.eclipse.core.resources.IProject;
  */
 class AppEngineStandardProjectConfig {
 
+  private URI eclipseProjectLocationUri = null;
   private String appEngineProjectId = "";
   private String packageName = "";
   private IProject project;
@@ -37,6 +40,14 @@ class AppEngineStandardProjectConfig {
 
   public IProject getProject() {
     return this.project;
+  }
+
+  public URI getEclipseProjectLocationUri() {
+    return this.eclipseProjectLocationUri;
+  }
+
+  public void setEclipseProjectLocationUri(URI uri) {
+    this.eclipseProjectLocationUri = uri;
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardWizardPage.java
@@ -1,6 +1,7 @@
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
 import java.io.File;
+import java.net.URI;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.IWizardPage;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardWizardPage.java
@@ -1,5 +1,7 @@
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
+import java.io.File;
+
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.ui.dialogs.WizardNewProjectCreationPage;
@@ -82,6 +84,13 @@ class AppEngineStandardWizardPage extends WizardNewProjectCreationPage implement
     String projectId = projectIdField.getText();
     if (!AppEngineProjectIdValidator.validate(projectId)) {
       setErrorMessage("Illegal App Engine Project ID: " + projectId); //$NON-NLS-1$
+      return false;
+    }
+    
+    File parent = getLocationPath().toFile();
+    File projectDirectory = new File(parent, getProjectName());
+    if (projectDirectory.exists()) {
+      setErrorMessage("Project location already exists: " + projectDirectory); 
       return false;
     }
     

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProject.java
@@ -52,14 +52,13 @@ class CreateAppEngineStandardWtpProject extends WorkspaceModifyOperation {
   }
 
   @Override
-  public void execute(IProgressMonitor monitor) throws InvocationTargetException, CoreException {
+  public void execute(IProgressMonitor monitor) throws InvocationTargetException, CoreException {    
     SubMonitor progress = SubMonitor.convert(monitor, 100);
-    
-    URI location = config.getProject().getLocationURI();
     
     IWorkspace workspace = ResourcesPlugin.getWorkspace();
     IProject newProject = config.getProject();
-    
+    URI location = newProject.getLocationURI();
+        
     String name = newProject.getName();
     final IProjectDescription description = workspace.newProjectDescription(name);
     description.setLocationURI(location);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProject.java
@@ -57,8 +57,8 @@ class CreateAppEngineStandardWtpProject extends WorkspaceModifyOperation {
     
     IWorkspace workspace = ResourcesPlugin.getWorkspace();
     IProject newProject = config.getProject();
-    URI location = newProject.getLocationURI();
-        
+    URI location = config.getEclipseProjectLocationUri();
+
     String name = newProject.getName();
     final IProjectDescription description = workspace.newProjectDescription(name);
     description.setLocationURI(location);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/StandardProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/StandardProjectWizard.java
@@ -36,6 +36,9 @@ public class StandardProjectWizard extends Wizard implements INewWizard {
     config.setPackageName(page.getPackageName());
 
     config.setProject(page.getProjectHandle());
+    if (!page.useDefaults()) {
+      config.setEclipseProjectLocationUri(page.getLocationURI());
+    }
     
     // todo set up
     final IAdaptable uiInfoAdapter = WorkspaceUndoUtil.getUIInfoAdapter(getShell());


### PR DESCRIPTION
fix #130 

Open questions:

1. Should we also check in CreateAppEngineStandardWtpProject?
2. Should the user have an option to overwrite an existing directory? (My gut says no. This is just a wizard. They can always do that manually if they want to, but let's not make it easy for the user to shoot themselves in the foot.)  