### PR TITLE
Fix #164 - Enable run/debug on local server

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegateTest.java
@@ -121,12 +121,10 @@ public class GCloudCommandDelegateTest {
                                                            1234,
                                                            2345);
 
-    assertEquals(sdkLocation + "/bin/dev_appserver.py "
-                 + runnables
-                 + " --api_host localhost --api_port 1234 "
-                 + "--jvm_flag=-Xdebug --jvm_flag=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,"
-                 + "address=2345",
-                 cmd);
+    assertEquals(sdkLocation + "/bin/dev_appserver.py " + runnables
+        + " --api_host localhost --api_port 1234 "
+        + "--jvm_flag=-Xdebug --jvm_flag=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,quiet=y,"
+        + "address=2345", cmd);
   }
 
   private String createOutput(String status) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegateTest.java
@@ -18,11 +18,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
-
-import org.junit.Test;
 
 /**
  * Unit tests for {@link GCloudCommandDelegate}
@@ -58,12 +58,12 @@ public class GCloudCommandDelegateTest {
 
   @Test(expected = NullPointerException.class)
   public void testCreateAppRunCommand_nullArgs() throws IOException {
-    GCloudCommandDelegate.createAppRunCommand(null, null, null, null, 0, 0);
+    GCloudCommandDelegate.createAppRunCommand(null, (String) null, null, null, 0, 0);
   }
 
   @Test(expected = InvalidPathException.class)
   public void testCreateAppRunCommand_invalidSdkLocation() throws IOException {
-    GCloudCommandDelegate.createAppRunCommand("sdkLocation", null, null, null, 0, 0);
+    GCloudCommandDelegate.createAppRunCommand("sdkLocation", (String) null, null, null, 0, 0);
   }
 
   @Test(expected = InvalidPathException.class)

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -301,4 +301,13 @@
             id="com.google.cloud.tools.eclipse.appengine.localserver.processfactory">
       </processFactory>
    </extension>
+   
+   <extension point="org.eclipse.wst.server.core.publishTasks">
+      <publishTask
+             id="com.google.appengine.eclipse.wtp.publishTask"
+             class="com.google.cloud.tools.eclipse.appengine.localserver.server.CloudSdkPublishTaskDelegate"
+             typeIds="com.google.cloud.tools.eclipse.server.id">
+       </publishTask>
+    </extension>
+   
 </plugin>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
@@ -118,39 +118,42 @@ public class GCloudCommandDelegate {
   }
 
   /**
-   * Creates a gcloud app run command. If {@code mode} is
-   * {@link ILaunchManager#DEBUG_MODE}, it configures the server to be run in
-   * debug mode using the "--jvm-flag" and also configures a debugger to be
-   * attached to the Cloud SDK server through {@code debugPort}.
+   * Creates a gcloud app run command. If {@code mode} is {@link ILaunchManager#DEBUG_MODE}, it
+   * configures the server to be run in debug mode using the "--jvm-flag" and also configures a
+   * debugger to be attached to the Cloud SDK server through {@code debugPort}.
    *
    * @param sdkLocation the location of the Cloud SDK
-   * @param runnables the application directory of the module to be run on the
-   *          server
+   * @param runnable the application directory of the module to be run on the server
    * @param mode the launch mode
-   * @param apiHost The host and port on which to start the API server (in the
-   *          format host:port)
+   * @param apiHost The host and port on which to start the API server (in the format host:port)
    * @param debugPort the debug port
    *
    * @return a gcloud app run command
    *
    * @throws IllegalStateException if {@code debugPort} is not between 1 and 65535
-   * @throws InvalidPathException if either the {@code sdkLocation} or {@code runnables}
-   *         denotes a path that does not exist
+   * @throws InvalidPathException if either the {@code sdkLocation} or {@code runnables} denotes a
+   *         path that does not exist
    * @throws NullPointerException if {@code apiHost} is null
    */
-  public static String createAppRunCommand(String sdkLocation,
-                                           String runnables,
-                                           String mode,
-                                           String apiHost,
-                                           int apiPort,
-                                           int debugPort) throws NullPointerException, InvalidPathException, IllegalStateException {
+  public static String createAppRunCommand(String sdkLocation, String runnable, String mode,
+      String apiHost, int apiPort, int debugPort)
+      throws NullPointerException, InvalidPathException, IllegalStateException {
+    return createAppRunCommand(sdkLocation, new String[] {runnable}, mode, apiHost, apiPort,
+        debugPort);
+  }
+
+  public static String createAppRunCommand(String sdkLocation, String[] runnables, String mode,
+      String apiHost, int apiPort, int debugPort)
+      throws NullPointerException, InvalidPathException, IllegalStateException {
 
     if (!(new File(sdkLocation)).exists()) {
       throw new InvalidPathException(sdkLocation, "Path does not exist");
     }
 
-    if (!(new File(runnables)).exists()) {
-      throw new InvalidPathException(runnables, "Path does not exist");
+    for (String runnable : runnables) {
+      if (!(new File(runnable)).exists()) {
+        throw new InvalidPathException(runnable, "Path does not exist");
+      }
     }
 
     if (apiHost == null) {
@@ -159,8 +162,11 @@ public class GCloudCommandDelegate {
 
     StringBuilder builder = new StringBuilder();
     builder.append(sdkLocation)
-           .append("/bin/dev_appserver.py ")
-           .append(runnables)
+        .append("/bin/dev_appserver.py ");
+    for (String runnable : runnables) {
+      builder.append(runnable).append(' ');
+    }
+    builder
            .append(" --api_host ")
            .append(apiHost)
            .append(" --api_port ")

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
@@ -176,7 +176,8 @@ public class GCloudCommandDelegate {
                                         + ", should be between 1-65535");
       }
       builder.append(" --jvm_flag=-Xdebug");
-      builder.append(" --jvm_flag=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=");
+      builder
+          .append(" --jvm_flag=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,quiet=y,address=");
       builder.append(debugPort);
     }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
@@ -14,19 +14,19 @@
  *******************************************************************************/
 package com.google.cloud.tools.eclipse.appengine.localserver;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.InvalidPathException;
-import java.util.regex.Pattern;
+import com.google.cloud.tools.eclipse.util.OSUtilities;
+import com.google.cloud.tools.eclipse.util.ProcessUtilities;
+import com.google.common.annotations.VisibleForTesting;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.wst.server.core.IRuntime;
 
-import com.google.cloud.tools.eclipse.util.OSUtilities;
-import com.google.cloud.tools.eclipse.util.ProcessUtilities;
-import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.util.regex.Pattern;
 
 /**
  * Utility class to run gcloud commands.
@@ -165,6 +165,10 @@ public class GCloudCommandDelegate {
            .append(apiHost)
            .append(" --api_port ")
            .append(apiPort);
+
+    // FIXME: workaround bug when running on a Java8 JVM
+    // https://github.com/GoogleCloudPlatform/gcloud-eclipse-tools/issues/181
+    builder.append(" --jvm_flag=-Dappengine.user.timezone=UTC");
 
     if ((mode != null) && mode.equals(ILaunchManager.DEBUG_MODE)) {
       if (debugPort <= 0 || debugPort > 65535) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
@@ -162,19 +162,15 @@ public class GCloudCommandDelegate {
 
     StringBuilder builder = new StringBuilder();
     builder.append(sdkLocation)
-        .append("/bin/dev_appserver.py ");
+        .append("/bin/dev_appserver.py");
     for (String runnable : runnables) {
-      builder.append(runnable).append(' ');
+      builder.append(' ').append(runnable);
     }
     builder
            .append(" --api_host ")
            .append(apiHost)
            .append(" --api_port ")
            .append(apiPort);
-
-    // FIXME: workaround bug when running on a Java8 JVM
-    // https://github.com/GoogleCloudPlatform/gcloud-eclipse-tools/issues/181
-    builder.append(" --jvm_flag=-Dappengine.user.timezone=UTC");
 
     if ((mode != null) && mode.equals(ILaunchManager.DEBUG_MODE)) {
       if (debugPort <= 0 || debugPort > 65535) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
@@ -129,11 +129,11 @@ public class CloudSdkLaunchConfigurationDelegate extends AbstractJavaLaunchConfi
 
       Activator.logInfo("Executing: " + commands);
 
-      Process p = Runtime.getRuntime().exec(commands, null);
+      Process process = Runtime.getRuntime().exec(commands, null);
       addProcessFactoryToLaunchConfiguration(configuration);
       // The DebugPlugin handles the streaming of the output to the console and
       // sends notifications of debug events
-      DebugPlugin.newProcess(launch, p, commands);
+      DebugPlugin.newProcess(launch, process, commands);
       serverBehaviour.addProcessListener(launch.getProcesses()[0]);
     } catch (IOException | NullPointerException | IllegalStateException | InvalidPathException e) {
       Activator.logError(e);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
@@ -14,11 +14,8 @@
  *******************************************************************************/
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.InvalidPathException;
-import java.util.HashMap;
-import java.util.Map;
+import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
+import com.google.cloud.tools.eclipse.appengine.localserver.GCloudCommandDelegate;
 
 import org.apache.maven.project.MavenProject;
 import org.eclipse.core.resources.IProject;
@@ -45,8 +42,11 @@ import org.eclipse.wst.server.core.IServerListener;
 import org.eclipse.wst.server.core.ServerEvent;
 import org.eclipse.wst.server.core.ServerUtil;
 
-import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
-import com.google.cloud.tools.eclipse.appengine.localserver.GCloudCommandDelegate;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Cloud SDK server's launch configuration delegate.
@@ -70,15 +70,19 @@ public class CloudSdkLaunchConfigurationDelegate extends AbstractJavaLaunchConfi
       return;
     }
 
-    String runnables = getRunnable(modules[0].getProject(), monitor);
+    CloudSdkServerBehaviour serverBehaviour =
+        (CloudSdkServerBehaviour) server.loadAdapter(CloudSdkServerBehaviour.class, null);
+    // todo: dev_appserver supports >= 1 module
+    IPath deployPath = serverBehaviour.getModuleDeployDirectory(modules[0]);
+    // was: String runnables = getRunnable(modules[0].getProject(), monitor);
+    String runnables = deployPath.toOSString();
+
     IRuntime runtime = server.getRuntime();
     if (runtime == null) {
       return;
     }
     IPath sdkLocation = runtime.getLocation();
 
-    CloudSdkServerBehaviour serverBehaviour = 
-    		(CloudSdkServerBehaviour) server.loadAdapter(CloudSdkServerBehaviour.class, null);
     serverBehaviour.setupLaunch(mode);
 
     final CloudSdkServer cloudSdkServer = CloudSdkServer.getCloudSdkServer(server);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
@@ -156,6 +156,9 @@ public class CloudSdkLaunchConfigurationDelegate extends AbstractJavaLaunchConfi
     if (modules == null || modules.length == 0) {
       abort("No modules associated with this server instance.", null, 0);
       return false;
+    } else if (ILaunchManager.DEBUG_MODE.equals(mode) && modules.length > 1) {
+      abort("Can only debug a single module.", null, 0);
+      return false;
     }
     return super.preLaunchCheck(configuration, mode, monitor);
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
@@ -114,11 +114,13 @@ public class CloudSdkLaunchConfigurationDelegate extends AbstractJavaLaunchConfi
 
     try {
       String commands = GCloudCommandDelegate.createAppRunCommand(sdkLocation.toOSString(),
-          runnables.toArray(new String[runnables.size()]),
-                                                                  mode,
-                                                                  cloudSdkServer.getApiHost(),
-                                                                  cloudSdkServer.getApiPort(),
-                                                                  debugPort);
+          runnables.toArray(new String[runnables.size()]), mode, cloudSdkServer.getApiHost(),
+          cloudSdkServer.getApiPort(), debugPort);
+
+      // FIXME: workaround bug when running on a Java8 JVM
+      // https://github.com/GoogleCloudPlatform/gcloud-eclipse-tools/issues/181
+      commands += " --jvm_flag=-Dappengine.user.timezone=UTC";
+
       Activator.logInfo("Executing: " + commands);
 
       Process p = Runtime.getRuntime().exec(commands, null);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkLaunchConfigurationDelegate.java
@@ -117,6 +117,12 @@ public class CloudSdkLaunchConfigurationDelegate extends AbstractJavaLaunchConfi
           runnables.toArray(new String[runnables.size()]), mode, cloudSdkServer.getApiHost(),
           cloudSdkServer.getApiPort(), debugPort);
 
+      String additionalFlags =
+          configuration.getAttribute(CloudSdkServer.SERVER_PROGRAM_FLAGS, (String) null);
+      if (additionalFlags != null) {
+        commands += " " + additionalFlags;
+      }
+
       // FIXME: workaround bug when running on a Java8 JVM
       // https://github.com/GoogleCloudPlatform/gcloud-eclipse-tools/issues/181
       commands += " --jvm_flag=-Dappengine.user.timezone=UTC";

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishOperation.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishOperation.java
@@ -70,7 +70,7 @@ public class CloudSdkPublishOperation extends PublishOperation {
 
   @Override
   public int getOrder() {
-    // TODO: shouldn't publishing tasks come later?
+    // TODO: should publishing tasks come later?
     // may be necessary to work with GWT compilation
     return 0;
   }
@@ -94,6 +94,7 @@ public class CloudSdkPublishOperation extends PublishOperation {
     // TODO: use more advanced key to store modules publish locations? Because a dependent
     // java project (added as child modules and published as jar) cannot present in more than one
     // parent modules.
+    // (Is this TODO still valid?)
     List<IStatus> statusList = Lists.newArrayList();
     IPath deployPath = server.getModuleDeployDirectory(modules[0]);
     if (modules.length == 1) {
@@ -281,7 +282,7 @@ public class CloudSdkPublishOperation extends PublishOperation {
   }
 
   /**
-   * Publish modules by zipping it into JAR file.
+   * Publish modules by zipping them into a JAR file.
    */
   private void publishJar(IPath path, Properties mapping, List<IStatus> statusList,
       IProgressMonitor monitor, IModule childModule) throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishOperation.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishOperation.java
@@ -99,6 +99,7 @@ public class CloudSdkPublishOperation extends PublishOperation {
       // root modules
       publishDir(deployPath, statusList, monitor);
     } else {
+      // BSD: NEED TO UNDERSTAND SITUATION FOR REMAINING CODE
       for (int i = 0; i < modules.length - 1; i++) {
         IPath deployPath = server.getModuleDeployDirectory(modules[i]);
         IWebModule webModule = (IWebModule) modules[i].loadAdapter(IWebModule.class, monitor);
@@ -118,7 +119,6 @@ public class CloudSdkPublishOperation extends PublishOperation {
           }
         }
       }
-      // BSD: NEED TO UNDERSTAND SITUATION FOR REMAINING CODE
       // BSD: Disabled saving and loading module locations
 
       // modules given as parent-child chain

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishOperation.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishOperation.java
@@ -1,0 +1,330 @@
+/*******************************************************************************
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.google.cloud.tools.eclipse.appengine.localserver.server;
+
+import com.google.common.collect.Lists;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jst.server.core.IJ2EEModule;
+import org.eclipse.jst.server.core.IWebModule;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.model.IModuleResource;
+import org.eclipse.wst.server.core.model.IModuleResourceDelta;
+import org.eclipse.wst.server.core.model.PublishOperation;
+import org.eclipse.wst.server.core.model.ServerBehaviourDelegate;
+import org.eclipse.wst.server.core.util.PublishHelper;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+public class CloudSdkPublishOperation extends PublishOperation {
+  private static final String PLUGIN_ID = CloudSdkPublishOperation.class.getName();
+
+  /**
+   * Throws new {@link CoreException} if status list is not empty.
+   */
+  private static void checkStatuses(List<IStatus> statusList) throws CoreException {
+    if (statusList == null || statusList.size() == 0) {
+      return;
+    }
+    if (statusList.size() == 1) {
+      throw new CoreException(statusList.get(0));
+    }
+    IStatus[] children = statusList.toArray(new IStatus[statusList.size()]);
+    throw new CoreException(
+        new MultiStatus(PLUGIN_ID, 0, children,
+        "Error during publish operation", null));
+  }
+
+  private CloudSdkServerBehaviour server;
+  private IModule[] modules;
+  private int kind;
+  private int deltaKind;
+  private PublishHelper helper;
+
+  public int getKind() {
+    return REQUIRED;
+  }
+
+  @Override
+  public int getOrder() {
+    // Hmm, shouldn't the publish tasks come later?
+    return 0;
+  }
+
+  /**
+   * Construct the operation object to publish the specified modules(s) to the specified server.
+   */
+  public CloudSdkPublishOperation(CloudSdkServerBehaviour server, int kind, IModule[] modules,
+      int deltaKind) {
+    super("Publish to server", "Publish a modules to App Engine Development Server");
+    this.server = server;
+    this.modules = modules;
+    this.kind = kind;
+    this.deltaKind = deltaKind;
+    IPath base = server.getRuntimeBaseDirectory();
+    helper = new PublishHelper(base.toFile());
+  }
+
+  @Override
+  public void execute(IProgressMonitor monitor, IAdaptable info) throws CoreException {
+    // TODO(amitin): use more advanced key to store modules publish locations? Because a dependent
+    // java project (added as child modules and published as jar) cannot present in more than one
+    // parent modules.
+    List<IStatus> statusList = Lists.newArrayList();
+    if (modules.length == 1) {
+      IPath deployPath = server.getModuleDeployDirectory(modules[0]);
+      // root modules
+      publishDir(deployPath, statusList, monitor);
+    } else {
+      for (int i = 0; i < modules.length - 1; i++) {
+        IPath deployPath = server.getModuleDeployDirectory(modules[i]);
+        IWebModule webModule = (IWebModule) modules[i].loadAdapter(IWebModule.class, monitor);
+        if (webModule == null) {
+          statusList.add(newErrorStatus("Not a Web modules: " + modules[i].getName()));
+          return;
+        }
+        String uri = webModule.getURI(modules[i + 1]);
+        if (uri != null) {
+          deployPath = deployPath.append(uri);
+        } else {
+          // no uri is OK for removed modules
+          if (deltaKind != ServerBehaviourDelegate.REMOVED) {
+            statusList
+                .add(newErrorStatus("Cannot get URI for modules: " + modules[i + 1].getName()));
+            return;
+          }
+        }
+      }
+      // BSD: NEED TO UNDERSTAND SITUATION FOR REMAINING CODE
+      // BSD: Disabled saving and loading module locations
+
+      // modules given as parent-child chain
+      // get last one, the prior modules should already be published
+      IPath deployPath = server.getModuleDeployDirectory(modules[0]);
+
+      IModule childModule = modules[modules.length - 1];
+      Properties moduleUrls = new Properties(); // FIXME: server.loadModulePublishLocations();
+      // get as j2ee
+      IJ2EEModule childJ2EEModule =
+          (IJ2EEModule) childModule.loadAdapter(IJ2EEModule.class, monitor);
+      if (childJ2EEModule != null && childJ2EEModule.isBinary()) {
+        publishArchiveModule(deployPath, moduleUrls, statusList, monitor, childModule);
+      } else {
+          publishDir(deployPath, moduleUrls, statusList, monitor, childModule);
+      }
+      // FIXME: server.saveModulePublishLocations(moduleUrls);
+    }
+    checkStatuses(statusList);
+    server.setModulePublishState2(modules, IServer.PUBLISH_STATE_NONE);
+  }
+
+  private IStatus newErrorStatus(String message) {
+    return new Status(IStatus.ERROR, getClass().getName(), message);
+  }
+
+  /**
+   * Publish as binary modules.
+   */
+  private void publishArchiveModule(IPath path, Properties mapping, List<IStatus> statusList,
+      IProgressMonitor monitor, IModule childModule) {
+    boolean isMoving = false;
+    // check older publish
+    String oldURI = (String) mapping.get(childModule.getId());
+    String jarURI = path.toOSString();
+    if (oldURI != null && jarURI != null) {
+      isMoving = !oldURI.equals(jarURI);
+    }
+    // setup target
+    IPath jarPath = (IPath) path.clone();
+    IPath deployPath = jarPath.removeLastSegments(1);
+    // remove if requested or if previously published and are now serving without publishing
+    if (isMoving || kind == IServer.PUBLISH_CLEAN || deltaKind == ServerBehaviourDelegate.REMOVED) {
+      if (oldURI != null) {
+        File file = new File(oldURI);
+        if (file.exists()) {
+          file.delete();
+        }
+      }
+      mapping.remove(childModule.getId());
+      if (deltaKind == ServerBehaviourDelegate.REMOVED) {
+        return;
+      }
+    }
+    // check for changes
+    if (!isMoving && kind != IServer.PUBLISH_CLEAN && kind != IServer.PUBLISH_FULL) {
+      IModuleResourceDelta[] delta = server.getPublishedResourceDelta(modules);
+      if (delta == null || delta.length == 0) {
+        return;
+      }
+    }
+    // ensure target directory
+    if (!deployPath.toFile().exists()) {
+      deployPath.toFile().mkdirs();
+    }
+    // do publish
+    IModuleResource[] resources = server.getResources(modules);
+    IStatus[] publishStatus = helper.publishToPath(resources, jarPath, monitor);
+    statusList.addAll(Arrays.asList(publishStatus));
+    // store into mapping
+    mapping.put(childModule.getId(), jarURI);
+  }
+
+  /**
+   * Publish modules as directory.
+   */
+  private void publishDir(IPath path, List<IStatus> statusList, IProgressMonitor monitor)
+      throws CoreException {
+    // delete if needed
+    if (kind == IServer.PUBLISH_CLEAN || deltaKind == ServerBehaviourDelegate.REMOVED) {
+      File file = path.toFile();
+      if (file.exists()) {
+        IStatus[] status = PublishHelper.deleteDirectory(file, monitor);
+        statusList.addAll(Arrays.asList(status));
+      }
+      // request for remove
+      if (deltaKind == ServerBehaviourDelegate.REMOVED) {
+        return;
+      }
+    }
+    // republish or publish fully
+    if (kind == IServer.PUBLISH_CLEAN || kind == IServer.PUBLISH_FULL) {
+      IModuleResource[] resources = server.getResources(modules);
+      IStatus[] publishStatus = helper.publishFull(resources, path, monitor);
+      statusList.addAll(Arrays.asList(publishStatus));
+      return;
+    }
+    // publish changes only
+    IModuleResourceDelta[] deltas = server.getPublishedResourceDelta(modules);
+    for (IModuleResourceDelta delta : deltas) {
+      IStatus[] publishStatus = helper.publishDelta(delta, path, monitor);
+      statusList.addAll(Arrays.asList(publishStatus));
+    }
+  }
+
+  /**
+   * Publish child modules as directory if not binary.
+   */
+  private void publishDir(IPath path, Properties mapping, List<IStatus> statusList,
+      IProgressMonitor monitor, IModule childModule) throws CoreException {
+    boolean isMoving = false;
+    // check older publish
+    String oldURI = (String) mapping.get(childModule.getId());
+    String dirURI = path.toOSString();
+    if (oldURI != null && dirURI != null) {
+      isMoving = !oldURI.equals(dirURI);
+    }
+    // setup target
+    IPath dirPath = (IPath) path.clone();
+    // remove if needed
+    if (isMoving || kind == IServer.PUBLISH_CLEAN || deltaKind == ServerBehaviourDelegate.REMOVED) {
+      if (oldURI != null) {
+        File file = new File(oldURI);
+        if (file.exists()) {
+          IStatus[] status = PublishHelper.deleteDirectory(file, monitor);
+          statusList.addAll(Arrays.asList(status));
+        }
+      }
+      mapping.remove(childModule.getId());
+      if (deltaKind == ServerBehaviourDelegate.REMOVED) {
+        return;
+      }
+    }
+    // check for changes
+    if (!isMoving && kind != IServer.PUBLISH_CLEAN && kind != IServer.PUBLISH_FULL) {
+      IModuleResourceDelta[] delta = server.getPublishedResourceDelta(modules);
+      if (delta == null || delta.length == 0) {
+        return;
+      }
+    }
+    // ensure directory exists
+    if (!dirPath.toFile().exists()) {
+      dirPath.toFile().mkdirs();
+    }
+    // do publish resources
+    // republish or publish fully
+    if (kind == IServer.PUBLISH_CLEAN || kind == IServer.PUBLISH_FULL) {
+      IModuleResource[] resources = server.getResources(modules);
+      IStatus[] publishStatus = helper.publishFull(resources, dirPath, monitor);
+      statusList.addAll(Arrays.asList(publishStatus));
+    } else {
+      // publish changes only
+      IModuleResourceDelta[] deltas = server.getPublishedResourceDelta(modules);
+      for (IModuleResourceDelta delta : deltas) {
+        IStatus[] publishStatus = helper.publishDelta(delta, dirPath, monitor);
+        statusList.addAll(Arrays.asList(publishStatus));
+      }
+    }
+    // store into mapping
+    mapping.put(childModule.getId(), dirURI);
+  }
+
+  /**
+   * Publish modules by zipping it into JAR file.
+   */
+  private void publishJar(IPath path, Properties mapping, List<IStatus> statusList,
+      IProgressMonitor monitor, IModule childModule) throws CoreException {
+    boolean isMoving = false;
+    // check older publish
+    String oldURI = (String) mapping.get(childModule.getId());
+    String jarURI = path.toOSString();
+    if (oldURI != null && jarURI != null) {
+      isMoving = !oldURI.equals(jarURI);
+    }
+    // setup target
+    IPath jarPath = (IPath) path.clone();
+    IPath deployDirectory = jarPath.removeLastSegments(1);
+    // remove if needed
+    if (isMoving || kind == IServer.PUBLISH_CLEAN || deltaKind == ServerBehaviourDelegate.REMOVED) {
+      if (oldURI != null) {
+        File file = new File(oldURI);
+        if (file.exists()) {
+          file.delete();
+        }
+      }
+      mapping.remove(childModule.getId());
+      if (deltaKind == ServerBehaviourDelegate.REMOVED) {
+        return;
+      }
+    }
+    // check for changes
+    if (!isMoving && kind != IServer.PUBLISH_CLEAN && kind != IServer.PUBLISH_FULL) {
+      IModuleResourceDelta[] delta = server.getPublishedResourceDelta(modules);
+      if (delta == null || delta.length == 0) {
+        return;
+      }
+    }
+    // ensure directory exists
+    if (!deployDirectory.toFile().exists()) {
+      deployDirectory.toFile().mkdirs();
+    }
+    // zip resources
+    IModuleResource[] resources = server.getResources(modules);
+    IStatus[] status = helper.publishZip(resources, jarPath, monitor);
+    statusList.addAll(Arrays.asList(status));
+    // store into mapping
+    mapping.put(childModule.getId(), jarURI);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishTaskDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishTaskDelegate.java
@@ -31,7 +31,8 @@ public class CloudSdkPublishTaskDelegate extends PublishTaskDelegate {
 
   @Override
   @SuppressWarnings("rawtypes")
-  public PublishOperation[] getTasks(IServer server, int kind, List modules, List kindList) {
+  public PublishOperation[] getTasks(IServer server, int kind, List/* <IModule[]> */ modules,
+      List/* <Integer> */ kindList) {
     if (modules == null || modules.isEmpty()) {
       return null;
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishTaskDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkPublishTaskDelegate.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.google.cloud.tools.eclipse.appengine.localserver.server;
+
+import com.google.common.collect.Lists;
+
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.model.PublishOperation;
+import org.eclipse.wst.server.core.model.PublishTaskDelegate;
+
+import java.util.List;
+
+/**
+ * Setup task for module publishing.
+ */
+public class CloudSdkPublishTaskDelegate extends PublishTaskDelegate {
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public PublishOperation[] getTasks(IServer server, int kind, List modules, List kindList) {
+    if (modules == null || modules.isEmpty()) {
+      return null;
+    }
+
+    CloudSdkServerBehaviour gaeServer =
+        (CloudSdkServerBehaviour) server.loadAdapter(CloudSdkServerBehaviour.class, null);
+
+    List<PublishOperation> tasks = Lists.newArrayList();
+    for (int i = 0; i < modules.size(); i++) {
+      IModule[] module = (IModule[]) modules.get(i);
+      tasks.add(new CloudSdkPublishOperation(gaeServer, kind, module, (Integer) kindList.get(i)));
+    }
+
+    return tasks.toArray(new PublishOperation[tasks.size()]);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkServer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkServer.java
@@ -14,8 +14,7 @@
  *******************************************************************************/
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -32,7 +31,8 @@ import org.eclipse.wst.server.core.ServerUtil;
 import org.eclipse.wst.server.core.internal.facets.FacetUtil;
 import org.eclipse.wst.server.core.model.ServerDelegate;
 
-import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A {@link ServerDelegate} for Google Cloud SDK.
@@ -133,13 +133,9 @@ public class CloudSdkServer extends ServerDelegate {
     List<String> modules = this.getAttribute(ATTR_CLOUD_SDK_SERVER_MODULES, (List<String>) null);
 
     if (add != null && add.length > 0) {
-      if (add.length > 1) {
-        throw new CoreException(new Status(IStatus.ERROR,
-                                           Activator.PLUGIN_ID,
-                                           0,
-                                           "This server instance cannot run more than one application",
-                                           null));
-      }
+      // TODO: ensure modules have same Project ID
+      // throw new CoreException(new Status(IStatus.ERROR, Activator.PLUGIN_ID, 0,
+      // "This server instance cannot run more than one application", null));
       if (modules == null) {
         modules = new ArrayList<>();
       }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkServerBehaviour.java
@@ -219,7 +219,7 @@ public class CloudSdkServerBehaviour extends ServerBehaviourDelegate {
   }
 
   /**
-   * Convenient method allowing access to protected method in superclass.
+   * Convenience method allowing access to protected method in superclass.
    */
   @Override
   protected IModuleResourceDelta[] getPublishedResourceDelta(IModule[] module) {
@@ -227,7 +227,7 @@ public class CloudSdkServerBehaviour extends ServerBehaviourDelegate {
   }
 
   /**
-   * Convenient method allowing access to protected method in superclass.
+   * Convenience method allowing access to protected method in superclass.
    */
   @Override
   protected IModuleResource[] getResources(IModule[] module) {
@@ -235,7 +235,7 @@ public class CloudSdkServerBehaviour extends ServerBehaviourDelegate {
   }
 
   /**
-   * Convenient accessor to protected member in superclass.
+   * Convenience accessor to protected member in superclass.
    */
   public void setModulePublishState2(IModule[] module, int state) {
     setModulePublishState(module, state);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/CloudSdkServerBehaviour.java
@@ -14,10 +14,9 @@
  *******************************************************************************/
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
-import java.io.IOException;
-import java.net.Socket;
-import java.net.URL;
+import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
 
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugEvent;
@@ -28,10 +27,15 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.model.IModuleResource;
+import org.eclipse.wst.server.core.model.IModuleResourceDelta;
 import org.eclipse.wst.server.core.model.ServerBehaviourDelegate;
 
-import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
+import java.io.IOException;
+import java.net.Socket;
+import java.net.URL;
 
 /**
  * A {@link ServerBehaviourDelegate} for Google Cloud SDK.
@@ -55,6 +59,13 @@ public class CloudSdkServerBehaviour extends ServerBehaviourDelegate {
       return new Status(IStatus.ERROR, Activator.PLUGIN_ID, message);
     }
     return Status.OK_STATUS;
+  }
+
+
+  @Override
+  public boolean canPublishModule(IModule[] module) {
+    // todo: should check module types?
+    return true;
   }
 
   @Override
@@ -192,4 +203,43 @@ public class CloudSdkServerBehaviour extends ServerBehaviourDelegate {
       Activator.logError("Error stopping the dev app server", e);
     }
   }
+
+  /**
+   * @return the directory at which module will be published.
+   */
+  public IPath getModuleDeployDirectory(IModule module) {
+    return getRuntimeBaseDirectory().append(module.getName());
+  }
+
+  /**
+   * Returns runtime base directory. Uses temp directory.
+   */
+  public IPath getRuntimeBaseDirectory() {
+    return getTempDirectory(false);
+  }
+
+  /**
+   * Convenient method allowing access to protected method in superclass.
+   */
+  @Override
+  protected IModuleResourceDelta[] getPublishedResourceDelta(IModule[] module) {
+    return super.getPublishedResourceDelta(module);
+  }
+
+  /**
+   * Convenient method allowing access to protected method in superclass.
+   */
+  @Override
+  protected IModuleResource[] getResources(IModule[] module) {
+    return super.getResources(module);
+  }
+
+  /**
+   * Convenient accessor to protected member in superclass.
+   */
+  public void setModulePublishState2(IModule[] module, int state) {
+    setModulePublishState(module, state);
+  }
+
+
 }


### PR DESCRIPTION
This feels a bit hacky:
  - explicitly specify timezone=UTC to avoid for the `NoSuchMethodException` on Java8
  - copy over module publishing from GPE; run `gcloud` from the published locations
  - run debug launch with `quiet=y` to avoid spurious messages on stdout, which interferes with `dev_appserver`'s communication with the running web server
  - add support for launching multiple `war`s (App Engine services): have to have same App Engine Application/Project ID, and distinct `<service>` names

PTAL @elharo — I might have a chance to look at this further tonight.