### PR TITLE
Assemble IDE Target Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,21 @@ This project provides an Eclipse plugin for building, debugging, and deploying G
 
 # Development
 
-## Import into Eclipse
+This project is built using _Maven Tycho_, a set of extensions to
+Maven for building Eclipse bundles and features.  As we also need
+to pull in some dependencies directly from Maven-style repositories,
+such as Maven Central and the Sonatype staging repository, we have
+a few hoops to jump through to set up a working development
+environment.
 
-### Requirements
+## Requirements
 
 1. Eclipse 4.5 (Mars) or later.  It's easiest to use the _Eclipse IDE for Java EE Developers_.
 
-1. The [m2eclipse plugin](http://www.eclipse.org/m2e/) (also called m2e) installed
-to import the projects into Eclipse.
+  1. The [m2eclipse plugin](http://www.eclipse.org/m2e/) (also called m2e) installed
+     to import the projects into Eclipse.
+
+1. Maven 3.3.9 or later.
 
 1. JDK 7
 
@@ -21,7 +28,22 @@ to import the projects into Eclipse.
 1. Clone the project to a local directory using `git clone
    https://github.com/GoogleCloudPlatform/gcloud-eclipse-tools.git`.
 
-### Steps to import
+## Import into Eclipse
+
+### Assemble the IDE Target Platform
+
+The Eclipse IDE and Tycho both use a _Target Platform_ to manage
+the dependencies for the source bundles and features under development.
+Although Tycho can pull dependencies directly from Maven-style
+repositories, Eclipse cannot.  So we use Tycho to cobble together
+a target platform suitable for the Eclipse IDE.
+```
+$ cd eclipse/ide-target-platform
+$ mvn package
+```
+
+### Steps to import into the Eclipse IDE
+
 
 1. Setup JDK 7 in Eclipse
 
@@ -67,17 +89,25 @@ to import the projects into Eclipse.
 
   1. Restart Eclipse when prompted.
 
+2. Set up the Target Platform
+
   1. Once Eclipse is running, open the `Preferences` again and go to `Plug-in
      Development/Target Platform`.
-
-  1. Set the checkbox next to one of the `Google Cloud Platform for Eclipse Mars`
-     target platforms (they are pointing to the same file), and click `Apply`.
-
-  1. After some time Eclipse will finish resolving and setting the target
-     platform, you can click `OK`.
-
-  1. There should be no errors in the `Markers` or `Problems` views in Eclipse. However
-      you may see several low-priority warnings.
+  2. Click _Add_ to create a new target platform.  Ignore the existing
+     _GCP_ targets listed there.
+  3. On the _Target Definition_ page, select _Nothing: Start with
+     an empty target definition_ and then click _Next_.
+  4. On the _Target Content_ page, give your target a new name like _IDE TP_.
+     Then click the _Add..._ button and choose _Directory_.
+  4. On the _Add Directory_ dialog, use _Browse..._ to navigate to
+     the `eclipse/ide-target-platform/target/repository` directory
+     found within this source repository and click _Finish_ to return to
+     the _Target Content_ page.
+  5. Click _Finish_ to complete the target platform creation.
+  6. Select your new Target Platform with a checkbox, and then click _OK_.
+  7. Eclipse will rebuild the workspace.  There should be no errors
+     in the `Markers` or `Problems` views in Eclipse. However
+     you may see several low-priority warnings.
 
 1. Check the imported project:
 
@@ -127,7 +157,9 @@ directory.  Compilation errors such as `java.lang.String` not found
 and `java.lang.Exception` not found
 indicate a misconfigured _jdkHome_.
 
-## Regenerating Target Platforms
+# Updating Target Platforms
+
+### Updating the `.target` files
 
 We use _Target Platform_ files (`.target`) to collect the dependencies used
 for the build.  These targets specify exact versions of the bundles and
@@ -163,3 +195,18 @@ The process is:
      to update the corresponding .target file.
 
 Both the `.tpd` and `.target` files should be committed.
+
+### Updating the Eclipse IDE Target Platforms
+
+The IDE Target Platform, defined in `eclipse/ide-target-platform`,
+may need to be updated when dependencies are added or removed.  The
+contents are defined in the `category.xml` file, which specifies
+the list of features and bundles that should be included.  This
+file can be edited using the Category editor in Eclipse.  Ideally
+the version should be specified as `"0.0.0"` to indicate that the
+current version found should be used.  Unlike the `.tpd` file,
+the identifiers are not p2 identifiers, and so features do not
+require the `.feature.group` suffix.
+
+
+

--- a/eclipse/ide-target-platform/.project
+++ b/eclipse/ide-target-platform/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>maven-dependencies</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/eclipse/ide-target-platform/.settings/org.eclipse.core.resources.prefs
+++ b/eclipse/ide-target-platform/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/eclipse/ide-target-platform/.settings/org.eclipse.m2e.core.prefs
+++ b/eclipse/ide-target-platform/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+  <feature id="org.eclipse.license" version="0.0.0"/>
+  <feature id="org.eclipse.sdk" version="0.0.0"/>
+  <feature id="org.eclipse.jdt" version="0.0.0"/>
+  <feature id="org.eclipse.m2e.feature" version="0.0.0"/>
+  <feature id="org.eclipse.m2e.wtp.feature" version="0.0.0"/>
+  <feature id="org.eclipse.mylyn.commons" version="0.0.0"/>
+  <feature id="org.eclipse.jpt.jpa.feature" version="0.0.0"/>
+  <feature id="org.eclipse.datatools.sdk.feature" version="0.0.0"/>
+  <feature id="org.eclipse.swtbot.eclipse" version="0.0.0"/>
+
+  <feature id="org.eclipse.jst.web_sdk.feature" version="0.0.0"/>
+  <feature id="org.eclipse.jst.server_sdk.feature" version="0.0.0"/>
+  <feature id="org.eclipse.wst.common.fproj.sdk" version="0.0.0"/>
+  <feature id="org.eclipse.wst.web_sdk.feature" version="0.0.0"/>
+  <feature id="org.eclipse.wst.server_adapters.sdk.feature" version="0.0.0"/>
+
+  <bundle id="org.eclipse.jetty.http" version="0.0.0"/>
+  <bundle id="org.eclipse.jetty.servlet" version="0.0.0"/>
+  <bundle id="org.eclipse.jetty.server" version="0.0.0"/>
+  <bundle id="org.eclipse.jetty.util" version="0.0.0"/>
+
+  <bundle id="org.hamcrest" version="1.1.0.v20090501071000" />
+  <bundle id="com.google.guava" version="17.0" />
+  <bundle id="com.google.gson" version="2.6.2" />
+  <bundle id="com.google.cloud.tools.app.lib" version="0.0.0" />
+
+</site>

--- a/eclipse/ide-target-platform/pom.xml
+++ b/eclipse/ide-target-platform/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.tools.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+  <artifactId>maven-dependencies.repo</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>eclipse-repository</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-repository-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <includeAllDependencies>true</includeAllDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
@@ -19,14 +19,42 @@
    </license>
 
    <plugin
-         id="com.google.guava"
+         id="org.hamcrest"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
    <plugin
+         id="org.hamcrest.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.hamcrest.library"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.google.guava"
+         download-size="0"
+         install-size="0"
+         version="17.0.0"
+         unpack="false"/>
+
+   <plugin
          id="com.google.gson"
+         download-size="0"
+         install-size="0"
+         version="2.6.2"
+         unpack="false"/>
+
+   <plugin
+         id="com.google.cloud.tools.app.lib"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
       <artifactId>app-tools-lib-for-java</artifactId>
       <version>0.1.0-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <!-- bundle: com.google.guava -->
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>17.0</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Tycho is able to resolve dependencies from Maven-style repositories (`pomDependencies=consider`), but the Eclipse IDE cannot.  This patch creates a new project in `eclipse/ide-target-platform` that assembles the dependencies from the Tycho build into a suitable target platform for the IDE.

Fixes #195