### PR TITLE
Remove need to include the 3rd party feature in the final build

### DIFF
--- a/gcp-repo/category.xml
+++ b/gcp-repo/category.xml
@@ -3,6 +3,5 @@
    <feature id="com.google.cloud.tools.eclipse.suite.e45.feature" version="0.1.0.qualifier">
       <category name="GCP"/>
    </feature>
-   <feature id="com.google.cloud.tools.eclipse.3rdparty.feature" version="0.1.0.qualifier"/>
    <category-def name="GCP" label="Cloud Tools for Eclipse"/>
 </site>

--- a/gcp-repo/invisible.product
+++ b/gcp-repo/invisible.product
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product uid="com.google.cloud.tools.eclipse.dist" version="1.0.0.qualifier" useFeatures="true" includeLaunchers="false">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+   </launcherArgs>
+
+   <features>
+      <feature id="com.google.cloud.tools.eclipse.3rdparty.feature" installMode="root"/>
+   </features>
+
+   <configurations>
+   </configurations>
+
+</product>

--- a/gcp-repo/pom.xml
+++ b/gcp-repo/pom.xml
@@ -21,6 +21,7 @@
         <artifactId>tycho-p2-repository-plugin</artifactId>
         <version>${tycho.version}</version>
         <configuration>
+          <repositoryName>Google Cloud Tools for Eclipse</repositoryName>
           <includeAllDependencies>false</includeAllDependencies>
         </configuration>
       </plugin>
@@ -33,12 +34,6 @@
             <id>materialize-products</id>
             <goals>
               <goal>materialize-products</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>archive-products</id>
-            <goals>
-              <goal>archive-products</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Change the `gcp-repo` project include the `com.google.cloud.tools.eclipse.3rdparty.feature` via an invisible product definition.  This fix ensures that the feature and its referenced bundles are included in the generated repository, but aren't listed as formally published features in the _Install New Software_ dialog.  I've also added a human-meaningful name for the repository, which is shown in the _Preferences > Install/Update > Available Software Sites_ if the user didn't explicitly specify a different label.

Fixes #234 