### PR TITLE
Change debug launch to use socket-listen instead of socket-connect

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegateTest.java
@@ -123,7 +123,7 @@ public class GCloudCommandDelegateTest {
 
     assertEquals(sdkLocation + "/bin/dev_appserver.py " + runnables
         + " --api_host localhost --api_port 1234 "
-        + "--jvm_flag=-Xdebug --jvm_flag=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,quiet=y,"
+        + "--jvm_flag=-Xdebug --jvm_flag=-Xrunjdwp:transport=dt_socket,server=n,suspend=y,quiet=y,"
         + "address=2345", cmd);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/GCloudCommandDelegate.java
@@ -179,7 +179,7 @@ public class GCloudCommandDelegate {
       }
       builder.append(" --jvm_flag=-Xdebug");
       builder
-          .append(" --jvm_flag=-Xrunjdwp:transport=dt_socket,server=y,suspend=y,quiet=y,address=");
+          .append(" --jvm_flag=-Xrunjdwp:transport=dt_socket,server=n,suspend=y,quiet=y,address=");
       builder.append(debugPort);
     }
 


### PR DESCRIPTION
Launching the dev_appserver in debug mode often fails due to timing
issues.  Although we have a 500ms wait, it seems insufficient
to ensure the remote JVM has gotten to a debuggable state and
so the debug connection fails.  We instead use the socket-listen
launch, such that the remote JVM connects to the debugger.

Fix #227