### PR TITLE
Set up preference page global to all plugins

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.preferences/.classpath
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/plugins/com.google.cloud.tools.eclipse.preferences/.project
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.google.cloud.tools.eclipse.preferences</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/com.google.cloud.tools.eclipse.preferences/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.7

--- a/plugins/com.google.cloud.tools.eclipse.preferences/.settings/org.eclipse.m2e.core.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/plugins/com.google.cloud.tools.eclipse.preferences/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/META-INF/MANIFEST.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin Preferences
+Bundle-SymbolicName: com.google.cloud.tools.eclipse.preferences;singleton:=true
+Bundle-Version: 0.1.0.qualifier
+Bundle-Vendor: Google, Inc.
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Export-Package: com.google.cloud.tools.eclipse.preferences
+Bundle-Activator: com.google.cloud.tools.eclipse.preferences.Activator
+Bundle-ActivationPolicy: lazy
+Require-Bundle: org.eclipse.ui,
+ org.eclipse.core.runtime

--- a/plugins/com.google.cloud.tools.eclipse.preferences/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/build.properties
@@ -1,0 +1,7 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = plugin.xml,\
+               META-INF/,\
+               .
+javacSource=1.7
+javacTarget=1.7

--- a/plugins/com.google.cloud.tools.eclipse.preferences/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/plugin.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            name="Google Cloud Tools"
+            class="com.google.cloud.tools.eclipse.preferences.CloudToolsPreferencePage"
+            id="com.google.cloud.tools.eclipse.preferences.preferences.CloudToolsPreferencePage">
+      </page>
+   </extension>
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="com.google.cloud.tools.eclipse.preferences.PreferenceInitializer">
+      </initializer>
+   </extension>
+
+</plugin>

--- a/plugins/com.google.cloud.tools.eclipse.preferences/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.tools.eclipse</groupId>
+    <version>0.1.0-SNAPSHOT</version>
+    <artifactId>trunk</artifactId>
+    <relativePath>../../</relativePath>
+  </parent>
+  <artifactId>com.google.cloud.tools.eclipse.preferences</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Activator.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Activator.java
@@ -9,40 +9,26 @@ import org.osgi.framework.BundleContext;
  */
 public class Activator extends AbstractUIPlugin {
 
-  // The plug-in ID
-  public static final String PLUGIN_ID = "com.google.cloud.tools.eclipse.preferences"; //$NON-NLS-1$
+  public static final String PLUGIN_ID = "com.google.cloud.tools.eclipse.preferences";
 
   // The shared instance
   private static Activator plugin;
 
-  /**
-   * The constructor
-   */
   public Activator() {
   }
 
-  /*
-   * (non-Javadoc)
-   * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
-   */
   public void start(BundleContext context) throws Exception {
     super.start(context);
     plugin = this;
   }
 
-  /*
-   * (non-Javadoc)
-   * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
-   */
   public void stop(BundleContext context) throws Exception {
     plugin = null;
     super.stop(context);
   }
 
   /**
-   * Returns the shared instance
-   *
-   * @return the shared instance
+   * Returns the shared instance.
    */
   public static Activator getDefault() {
     return plugin;
@@ -50,10 +36,7 @@ public class Activator extends AbstractUIPlugin {
 
   /**
    * Returns an image descriptor for the image file at the given
-   * plug-in relative path
-   *
-   * @param path the path
-   * @return the image descriptor
+   * plug-in relative path.
    */
   public static ImageDescriptor getImageDescriptor(String path) {
     return imageDescriptorFromPlugin(PLUGIN_ID, path);

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Activator.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Activator.java
@@ -1,0 +1,61 @@
+package com.google.cloud.tools.eclipse.preferences;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle
+ */
+public class Activator extends AbstractUIPlugin {
+
+  // The plug-in ID
+  public static final String PLUGIN_ID = "com.google.cloud.tools.eclipse.preferences"; //$NON-NLS-1$
+
+  // The shared instance
+  private static Activator plugin;
+
+  /**
+   * The constructor
+   */
+  public Activator() {
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
+   */
+  public void start(BundleContext context) throws Exception {
+    super.start(context);
+    plugin = this;
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+   */
+  public void stop(BundleContext context) throws Exception {
+    plugin = null;
+    super.stop(context);
+  }
+
+  /**
+   * Returns the shared instance
+   *
+   * @return the shared instance
+   */
+  public static Activator getDefault() {
+    return plugin;
+  }
+
+  /**
+   * Returns an image descriptor for the image file at the given
+   * plug-in relative path
+   *
+   * @param path the path
+   * @return the image descriptor
+   */
+  public static ImageDescriptor getImageDescriptor(String path) {
+    return imageDescriptorFromPlugin(PLUGIN_ID, path);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
@@ -33,15 +33,15 @@ public class AnalyticsOptInFieldEditor extends FieldEditor {
    */
   public AnalyticsOptInFieldEditor(String name, Composite parent) {
     group = new Group(parent, SWT.SHADOW_OUT);
-    group.setText(Messages.FIELD_EDITOR_ANALYTICS_GROUP_TITLE);
+    group.setText(Messages.ANALYTICS_PREF_GROUP_TITLE);
 
     // Opt-in checkbox with a label
     optInStatusEditor =
-        new BooleanFieldEditor(name, Messages.FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT, group);
+        new BooleanFieldEditor(name, Messages.ANALYTICS_OPT_IN_TEXT, group);
 
     // The privacy policy disclaimer with a clickable link
     Link link = new Link(group, SWT.NONE);
-    link.setText(Messages.FIELD_EDITOR_ANALYTICS_DISCLAIMER);
+    link.setText(Messages.ANALYTICS_DISCLAIMER);
     link.addSelectionListener(new SelectionAdapter() {
       @Override
       public void widgetSelected(SelectionEvent event) {

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
@@ -1,15 +1,28 @@
 package com.google.cloud.tools.eclipse.preferences;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Link;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
 
 public class AnalyticsOptInFieldEditor extends FieldEditor {
+
+  private static final Logger logger = Logger.getLogger(AnalyticsOptInFieldEditor.class.getName());
 
   private Group group;
   private BooleanFieldEditor optInStatusEditor;
@@ -22,12 +35,30 @@ public class AnalyticsOptInFieldEditor extends FieldEditor {
     group = new Group(parent, SWT.SHADOW_OUT);
     group.setText(Messages.FIELD_EDITOR_ANALYTICS_GROUP_TITLE);
 
+    // Opt-in checkbox with a label
     optInStatusEditor =
         new BooleanFieldEditor(name, Messages.FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT, group);
 
+    // The privacy policy disclaimer with a clickable link
     Link link = new Link(group, SWT.NONE);
     link.setText(Messages.FIELD_EDITOR_ANALYTICS_DISCLAIMER);
+    link.addSelectionListener(new SelectionAdapter() {
+      @Override
+      public void widgetSelected(SelectionEvent event) {
+        // Open a privacy policy web page when the link is clicked.
+        try {
+          URL url = new URL(Messages.GOOGLE_PRIVACY_POLICY_URL);
+          IWorkbenchBrowserSupport browserSupport = PlatformUI.getWorkbench().getBrowserSupport();
+          browserSupport.createBrowser(null).openURL(url);
+        } catch (MalformedURLException mue) {
+          logger.log(Level.WARNING, "URL malformed", mue);
+        } catch (PartInitException pie) {
+          logger.log(Level.WARNING, "Cannot launch a browser", pie);
+        }
+      }
+    });
 
+    // Initialize and set up this object.
     init(name, "labelless field editor");
     createControl(parent);
   }
@@ -53,6 +84,8 @@ public class AnalyticsOptInFieldEditor extends FieldEditor {
     GridData gridData = new GridData();
     gridData.horizontalSpan = numColumns;
     group.setLayoutData(gridData);
+
+    GridLayoutFactory.swtDefaults().applyTo(group);
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
@@ -36,8 +36,7 @@ public class AnalyticsOptInFieldEditor extends FieldEditor {
     group.setText(Messages.ANALYTICS_PREF_GROUP_TITLE);
 
     // Opt-in checkbox with a label
-    optInStatusEditor =
-        new BooleanFieldEditor(name, Messages.ANALYTICS_OPT_IN_TEXT, group);
+    optInStatusEditor = new BooleanFieldEditor(name, Messages.ANALYTICS_OPT_IN_TEXT, group);
 
     // The privacy policy disclaimer with a clickable link
     Link link = new Link(group, SWT.NONE);

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
@@ -33,7 +33,7 @@ public class AnalyticsOptInFieldEditor extends FieldEditor {
    */
   public AnalyticsOptInFieldEditor(String name, Composite parent) {
     group = new Group(parent, SWT.SHADOW_OUT);
-    group.setText(Messages.ANALYTICS_PREF_GROUP_TITLE);
+    group.setText(Messages.ANALYTICS_PREFERENCE_GROUP_TITLE);
 
     // Opt-in checkbox with a label
     optInStatusEditor = new BooleanFieldEditor(name, Messages.ANALYTICS_OPT_IN_TEXT, group);

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/AnalyticsOptInFieldEditor.java
@@ -1,0 +1,73 @@
+package com.google.cloud.tools.eclipse.preferences;
+
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditor;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Link;
+
+public class AnalyticsOptInFieldEditor extends FieldEditor {
+
+  private Group group;
+  private BooleanFieldEditor optInStatusEditor;
+
+  /**
+   * @param name the name of the preference this field editor works on
+   * @param parent the parent of the field editor's control
+   */
+  public AnalyticsOptInFieldEditor(String name, Composite parent) {
+    group = new Group(parent, SWT.SHADOW_OUT);
+    group.setText(Messages.FIELD_EDITOR_ANALYTICS_GROUP_TITLE);
+
+    optInStatusEditor =
+        new BooleanFieldEditor(name, Messages.FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT, group);
+
+    Link link = new Link(group, SWT.NONE);
+    link.setText(Messages.FIELD_EDITOR_ANALYTICS_DISCLAIMER);
+
+    init(name, "labelless field editor");
+    createControl(parent);
+  }
+
+  @Override
+  public void setPreferenceStore(IPreferenceStore store) {
+    super.setPreferenceStore(store);
+    optInStatusEditor.setPreferenceStore(store);
+  }
+
+  @Override
+  public int getNumberOfControls() {
+    return 1;
+  }
+
+  @Override
+  protected void adjustForNumColumns(int numColumns) {
+    ((GridData) group.getLayoutData()).horizontalSpan = numColumns;
+  }
+
+  @Override
+  protected void doFillIntoGrid(Composite parent, int numColumns) {
+    GridData gridData = new GridData();
+    gridData.horizontalSpan = numColumns;
+    group.setLayoutData(gridData);
+  }
+
+  @Override
+  protected void doLoad() {
+    optInStatusEditor.load();
+  }
+
+  @Override
+  protected void doLoadDefault() {
+    optInStatusEditor.loadDefault();
+  }
+
+  @Override
+  protected void doStore() {
+    optInStatusEditor.store();
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/CloudToolsPreferencePage.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/CloudToolsPreferencePage.java
@@ -8,7 +8,7 @@ import org.eclipse.ui.IWorkbench;
  * This class represents a preference page that is contributed to the
  * Preferences dialog. By subclassing <samp>FieldEditorPreferencePage</samp>, we
  * can use the field support built into JFace that allows us to create a page
- * that is small and knows how to save, restore and apply itself.
+ * that is small and knows how to save, restore, and apply itself.
  * <p>
  * This page is used to modify preferences only. They are stored in the
  * preference store that belongs to the main plug-in class. That way,

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/CloudToolsPreferencePage.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/CloudToolsPreferencePage.java
@@ -1,0 +1,35 @@
+package com.google.cloud.tools.eclipse.preferences;
+
+import org.eclipse.jface.preference.*;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.eclipse.ui.IWorkbench;
+
+/**
+ * This class represents a preference page that is contributed to the
+ * Preferences dialog. By subclassing <samp>FieldEditorPreferencePage</samp>, we
+ * can use the field support built into JFace that allows us to create a page
+ * that is small and knows how to save, restore and apply itself.
+ * <p>
+ * This page is used to modify preferences only. They are stored in the
+ * preference store that belongs to the main plug-in class. That way,
+ * preferences can be accessed directly via the preference store.
+ */
+
+public class CloudToolsPreferencePage extends FieldEditorPreferencePage
+    implements IWorkbenchPreferencePage {
+
+  public static final String ANALYTICS_OPT_IN = "ANALYTICS_OPT_IN";
+
+  public CloudToolsPreferencePage() {
+    super(GRID);
+    setPreferenceStore(Activator.getDefault().getPreferenceStore());
+  }
+
+  public void createFieldEditors() {
+    addField(new AnalyticsOptInFieldEditor(ANALYTICS_OPT_IN, getFieldEditorParent()));
+  }
+
+  public void init(IWorkbench workbench) {
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Messages.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Messages.java
@@ -4,9 +4,9 @@ import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
   private static final String BUNDLE_NAME = "com.google.cloud.tools.eclipse.preferences.messages";
-  public static String FIELD_EDITOR_ANALYTICS_DISCLAIMER;
-  public static String FIELD_EDITOR_ANALYTICS_GROUP_TITLE;
-  public static String FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT;
+  public static String ANALYTICS_DISCLAIMER;
+  public static String ANALYTICS_PREF_GROUP_TITLE;
+  public static String ANALYTICS_OPT_IN_TEXT;
   public static String GOOGLE_PRIVACY_POLICY_URL;
   static {
     NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Messages.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Messages.java
@@ -5,7 +5,7 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS {
   private static final String BUNDLE_NAME = "com.google.cloud.tools.eclipse.preferences.messages";
   public static String ANALYTICS_DISCLAIMER;
-  public static String ANALYTICS_PREF_GROUP_TITLE;
+  public static String ANALYTICS_PREFERENCE_GROUP_TITLE;
   public static String ANALYTICS_OPT_IN_TEXT;
   public static String GOOGLE_PRIVACY_POLICY_URL;
   static {

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Messages.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Messages.java
@@ -1,0 +1,17 @@
+package com.google.cloud.tools.eclipse.preferences;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS {
+  private static final String BUNDLE_NAME = "com.google.cloud.tools.eclipse.preferences.messages"; //$NON-NLS-1$
+  public static String FIELD_EDITOR_ANALYTICS_DISCLAIMER;
+  public static String FIELD_EDITOR_ANALYTICS_GROUP_TITLE;
+  public static String FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT;
+  static {
+    // initialize resource bundle
+    NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+  }
+
+  private Messages() {
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Messages.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/Messages.java
@@ -3,12 +3,12 @@ package com.google.cloud.tools.eclipse.preferences;
 import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
-  private static final String BUNDLE_NAME = "com.google.cloud.tools.eclipse.preferences.messages"; //$NON-NLS-1$
+  private static final String BUNDLE_NAME = "com.google.cloud.tools.eclipse.preferences.messages";
   public static String FIELD_EDITOR_ANALYTICS_DISCLAIMER;
   public static String FIELD_EDITOR_ANALYTICS_GROUP_TITLE;
   public static String FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT;
+  public static String GOOGLE_PRIVACY_POLICY_URL;
   static {
-    // initialize resource bundle
     NLS.initializeMessages(BUNDLE_NAME, Messages.class);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/PreferenceInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/PreferenceInitializer.java
@@ -1,0 +1,21 @@
+package com.google.cloud.tools.eclipse.preferences;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.jface.preference.IPreferenceStore;
+
+/**
+ * Class used to initialize default preference values.
+ */
+public class PreferenceInitializer extends AbstractPreferenceInitializer {
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#initializeDefaultPreferences()
+   */
+  public void initializeDefaultPreferences() {
+    IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+    store.setDefault(CloudToolsPreferencePage.ANALYTICS_OPT_IN, false);
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/PreferenceInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/PreferenceInitializer.java
@@ -8,11 +8,6 @@ import org.eclipse.jface.preference.IPreferenceStore;
  */
 public class PreferenceInitializer extends AbstractPreferenceInitializer {
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#initializeDefaultPreferences()
-   */
   public void initializeDefaultPreferences() {
     IPreferenceStore store = Activator.getDefault().getPreferenceStore();
     store.setDefault(CloudToolsPreferencePage.ANALYTICS_OPT_IN, false);

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/messages.properties
@@ -1,3 +1,4 @@
-FIELD_EDITOR_ANALYTICS_DISCLAIMER=Your use of this plugin is subject to the Apache 2.0 software license and the <a href="privacy-policy">Google Privacy Policy</a>.
+FIELD_EDITOR_ANALYTICS_DISCLAIMER=Your use of this plug-in is subject to the Apache 2.0 software license and the <a href="privacy-policy">Google Privacy Policy</a>.
 FIELD_EDITOR_ANALYTICS_GROUP_TITLE=Usage Statistics
-FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT=&Share anonymous usage statistics of Google Cloud Plugins with Google
+FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT=&Share anonymous usage statistics of Google Cloud Tools with Google
+GOOGLE_PRIVACY_POLICY_URL=http://www.google.com/policies/privacy/

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/messages.properties
@@ -1,0 +1,3 @@
+FIELD_EDITOR_ANALYTICS_DISCLAIMER=Your use of this plugin is subject to the Apache 2.0 software license and the <a href="privacy-policy">Google Privacy Policy</a>.
+FIELD_EDITOR_ANALYTICS_GROUP_TITLE=Usage Statistics
+FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT=&Share anonymous usage statistics of Google Cloud Plugins with Google

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/messages.properties
@@ -1,4 +1,4 @@
 ANALYTICS_DISCLAIMER=Sharing usage statistics is subject to the <a href="privacy-policy">Google Privacy Policy</a>.
-ANALYTICS_PREF_GROUP_TITLE=Usage Statistics
+ANALYTICS_PREFERENCE_GROUP_TITLE=Usage Statistics
 ANALYTICS_OPT_IN_TEXT=&Share anonymous usage statistics of Google Cloud Tools with Google
 GOOGLE_PRIVACY_POLICY_URL=http://www.google.com/policies/privacy/

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/messages.properties
@@ -1,4 +1,4 @@
-FIELD_EDITOR_ANALYTICS_DISCLAIMER=Your use of this plug-in is subject to the Apache 2.0 software license and the <a href="privacy-policy">Google Privacy Policy</a>.
-FIELD_EDITOR_ANALYTICS_GROUP_TITLE=Usage Statistics
-FIELD_EDITOR_ANALYTICS_OPT_IN_TEXT=&Share anonymous usage statistics of Google Cloud Tools with Google
+ANALYTICS_DISCLAIMER=Sharing usage statistics is subject to the <a href="privacy-policy">Google Privacy Policy</a>.
+ANALYTICS_PREF_GROUP_TITLE=Usage Statistics
+ANALYTICS_OPT_IN_TEXT=&Share anonymous usage statistics of Google Cloud Tools with Google
 GOOGLE_PRIVACY_POLICY_URL=http://www.google.com/policies/privacy/

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <module>plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test</module>
     <module>plugins/com.google.cloud.tools.eclipse.appengine.ui</module>
     <module>plugins/com.google.cloud.tools.eclipse.appengine.ui.test</module>
+    <module>plugins/com.google.cloud.tools.eclipse.preferences</module>
     <module>plugins/com.google.cloud.tools.eclipse.usagetracker</module>
     <module>plugins/com.google.cloud.tools.eclipse.usagetracker.test</module>
     <module>plugins/com.google.cloud.tools.eclipse.test.dependencies</module>


### PR DESCRIPTION
Sets up a new plugin bundle to accommodate plugin-wide preferences. Also a pre-requisite for #138. It adds a root entry "Google Cloud Tools" to the preference page. (See the screenshot below.)

This bundle is a plugin (i.e., contains 'plugin.xml') and also has an Activator. I thought these are necessary to set up a preference store and UI.

![preference_page](https://cloud.githubusercontent.com/assets/10523105/16062528/a3740cce-3261-11e6-99d9-5734b3e3323f.png)

I still have to find a way to launch a web browser when a user clicks on the hyperlink (the "Google Privacy Policy" text).

About `AnalyticsOptInFieldEditor`: I created this class in order to put two controls (`BooleanFieldEditor` and `Link`) into a `Group` (i.e., a panel with a border) to have a nice-looking UI. I couldn't find a way to do so without directly extending the general base `FieldEditor` class.