### PR TITLE
Follow the convention /virtual/eventType/eventName

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerTest.java
@@ -87,7 +87,14 @@ public class AnalyticsPingManagerTest {
   public void testEventTypeEventNameConvention() {
     Map<String, String> parameters =
         AnalyticsPingManager.buildParametersMap("some.event-name", null, null);
-    Assert.assertEquals("/virtual/" + AnalyticsPingManager.APPLICATION_NAME + "/some.event-name",
+    Assert.assertEquals("/virtual/gcloud-eclipse-tools/some.event-name",
         parameters.get("dp"));
+  }
+
+  @Test
+  public void testMetadataConvention() {
+    Map<String, String> parameters =
+        AnalyticsPingManager.buildParametersMap("some.event-name", "times-happened", "1234");
+    Assert.assertEquals("times-happened=1234", parameters.get("dt"));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerTest.java
@@ -82,4 +82,12 @@ public class AnalyticsPingManagerTest {
         + "%24%25%5E%26%28%29%3F%3C%3E%7B%7D%5D%5B%7C%3A%3B%2F%5C%27%22",
         AnalyticsPingManager.getParametersString(escape));
   }
+
+  @Test
+  public void testEventTypeEventNameConvention() {
+    Map<String, String> parameters =
+        AnalyticsPingManager.buildParametersMap("some.event-name", null, null);
+    Assert.assertEquals("/virtual/" + AnalyticsPingManager.APPLICATION_NAME + "/some.event-name",
+        parameters.get("dp"));
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -102,18 +102,17 @@ public class AnalyticsPingManager {
     }
   }
 
-  public static void sendPing(String eventType, String eventName,
-      String metadataKey, String metadataValue) {
+  public static void sendPing(String eventName, String metadataKey, String metadataValue) {
     if (Platform.inDevelopmentMode() || !isTrackingIdDefined() || !hasUserOptedIn()) {
       return;
     }
 
     Map<String, String> parametersMap = new HashMap<>(STANDARD_PARAMETERS);
     parametersMap.put("cid", getAnonymizedClientId());
-    parametersMap.put("cd19", eventType);
+    parametersMap.put("cd19", APPLICATION_NAME);
     parametersMap.put("cd20", eventName);
 
-    String virtualPageUrl = "/virtual/" + APPLICATION_NAME + "/" + eventType + "/" + eventName;
+    String virtualPageUrl = "/virtual/" + APPLICATION_NAME + "/" + eventName;
     parametersMap.put("dp", virtualPageUrl);
 
     if (metadataKey != null) {

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -37,8 +37,7 @@ public class AnalyticsPingManager {
   private static final String ANALYTICS_COLLECTION_URL = "https://ssl.google-analytics.com/collect";
 
   // This name will be recorded as an originating app on Google Analytics.
-  @VisibleForTesting
-  static final String APPLICATION_NAME = "gcloud-eclipse-tools";
+  private static final String APPLICATION_NAME = "gcloud-eclipse-tools";
 
   // Fixed-value query parameters present in every ping, and their fixed values:
   //


### PR DESCRIPTION
The backend team says we should follow the convention of

/virtual/<event type>/<event name>

Per discussion in https://github.com/GoogleCloudPlatform/gcloud-intellij/pull/754#discussion_r68245423, we set the event type to our application name.