### PR TITLE
Make a message posted / set connection timeout

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -13,9 +13,7 @@ import org.osgi.service.prefs.BackingStoreException;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-import java.io.Writer;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -140,10 +140,16 @@ public class AnalyticsPingManager {
       connection.setDoOutput(true);
       connection.setRequestMethod("POST");
       connection.setRequestProperty("Content-Length", Integer.toString(parametersString.length()));
+      connection.setReadTimeout(3000);  // milliseconds
 
       try (Writer writer = new OutputStreamWriter(connection.getOutputStream(), "UTF-8")) {
         writer.write(parametersString);
         writer.flush();
+      }
+
+      int responseCode = connection.getResponseCode();
+      if (responseCode != 200) {
+        logger.log(Level.WARNING, "Response code not 200: " + responseCode);
       }
     } catch (IOException ex) {
       // Don't try to recover or retry.

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -12,6 +12,7 @@ import org.eclipse.ui.PlatformUI;
 import org.osgi.service.prefs.BackingStoreException;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
@@ -122,8 +123,11 @@ public class AnalyticsPingManager {
       connection.setReadTimeout(3000);  // milliseconds
       byte[] bytesToWrite = parametersString.getBytes("UTF-8");
       connection.setFixedLengthStreamingMode(bytesToWrite.length);
-      connection.getOutputStream().write(bytesToWrite);
-      connection.getOutputStream().flush();
+
+      try (OutputStream out = connection.getOutputStream()) {
+        out.write(bytesToWrite);
+        out.flush();
+      }
     } catch (IOException ex) {
       // Don't try to recover or retry.
       logger.log(Level.WARNING, "Failed to send a POST request", ex);

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -119,7 +119,7 @@ public class AnalyticsPingManager {
       connection = (HttpURLConnection) url.openConnection();
       connection.setDoOutput(true);
       connection.setRequestMethod("POST");
-      connection.setFixedLengthStreamingMode(parametersString.length());
+      connection.setFixedLengthStreamingMode(parametersString.getBytes("UTF-8").length);
       connection.setReadTimeout(3000);  // milliseconds
 
       try (Writer writer = new OutputStreamWriter(connection.getOutputStream(), "UTF-8")) {

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -139,15 +139,13 @@ public class AnalyticsPingManager {
       connection = (HttpURLConnection) url.openConnection();
       connection.setDoOutput(true);
       connection.setRequestMethod("POST");
-      connection.setRequestProperty("Content-Length", Integer.toString(parametersString.length()));
+      connection.setFixedLengthStreamingMode(parametersString.length());
       connection.setReadTimeout(3000);  // milliseconds
 
       try (Writer writer = new OutputStreamWriter(connection.getOutputStream(), "UTF-8")) {
         writer.write(parametersString);
         writer.flush();
       }
-
-      connection.getResponseCode();  // This call is important to ensure posting the request.
     } catch (IOException ex) {
       // Don't try to recover or retry.
       logger.log(Level.WARNING, "Failed to send a POST request", ex);

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -119,13 +119,11 @@ public class AnalyticsPingManager {
       connection = (HttpURLConnection) url.openConnection();
       connection.setDoOutput(true);
       connection.setRequestMethod("POST");
-      connection.setFixedLengthStreamingMode(parametersString.getBytes("UTF-8").length);
       connection.setReadTimeout(3000);  // milliseconds
-
-      try (Writer writer = new OutputStreamWriter(connection.getOutputStream(), "UTF-8")) {
-        writer.write(parametersString);
-        writer.flush();
-      }
+      byte[] bytesToWrite = parametersString.getBytes("UTF-8");
+      connection.setFixedLengthStreamingMode(bytesToWrite.length);
+      connection.getOutputStream().write(bytesToWrite);
+      connection.getOutputStream().flush();
     } catch (IOException ex) {
       // Don't try to recover or retry.
       logger.log(Level.WARNING, "Failed to send a POST request", ex);

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -147,7 +147,7 @@ public class AnalyticsPingManager {
         writer.flush();
       }
 
-      connection.getResponseCode();  // Important: ensure this request posted.
+      connection.getResponseCode();  // This call is important to ensure posting the request.
     } catch (IOException ex) {
       // Don't try to recover or retry.
       logger.log(Level.WARNING, "Failed to send a POST request", ex);

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -147,10 +147,7 @@ public class AnalyticsPingManager {
         writer.flush();
       }
 
-      int responseCode = connection.getResponseCode();
-      if (responseCode != 200) {
-        logger.log(Level.WARNING, "Response code not 200: " + responseCode);
-      }
+      connection.getResponseCode();  // Important: ensure this request posted.
     } catch (IOException ex) {
       // Don't try to recover or retry.
       logger.log(Level.WARNING, "Failed to send a POST request", ex);


### PR DESCRIPTION
All of a sudden, I noticed that AnalyticsPingManager is not sending a HTTP request, despite the connection being made and closed actually. (No idea why.)

Calling `getResponseCode()` ensures the event message is sent.

I also set a timeout for the extremely unlikely event of the backend server holding a connection while not sending any output back. (This will never happen actually.)