### PR TITLE
sendPing() triggers showing opt-in dialog

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/CloudToolsPreferencePage.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/CloudToolsPreferencePage.java
@@ -17,6 +17,7 @@ import org.eclipse.ui.IWorkbench;
 public class CloudToolsPreferencePage extends FieldEditorPreferencePage
     implements IWorkbenchPreferencePage {
 
+  // See AnalyticsPingManager for the details of these fields.
   public static final String ANALYTICS_OPT_IN = "ANALYTICS_OPT_IN";
   public static final String ANALYTICS_OPT_IN_REGISTERED = "ANALYTICS_OPT_IN_REGISTERED";
   public static final String ANALYTICS_CLIENT_ID = "ANALYTICS_CLIENT_ID";

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker.test/META-INF/MANIFEST.MF
@@ -6,4 +6,7 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.usagetracker.test
 Bundle-Vendor: Google, Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.usagetracker
-Require-Bundle: org.junit
+Require-Bundle: org.junit,
+ org.eclipse.equinox.preferences,
+ com.google.cloud.tools.eclipse.test.dependencies;bundle-version="0.1.0",
+ org.eclipse.swt

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerTest.java
@@ -165,7 +165,7 @@ public class AnalyticsPingManagerTest {
     OptInDialogCreator dialogCreator = mock(OptInDialogCreator.class);
     when(dialogCreator.create(any(Shell.class))).thenReturn(optInDialog);
 
-    new AnalyticsPingManager(preferences, dialogCreator).showOptInDialog(new Shell());
+    new AnalyticsPingManager(preferences, dialogCreator).showOptInDialog(null);
     verify(optInDialog, verificationMode).open();
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerTest.java
@@ -1,11 +1,25 @@
 package com.google.cloud.tools.eclipse.usagetracker;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.swt.widgets.Shell;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.verification.VerificationMode;
+
+import com.google.cloud.tools.eclipse.preferences.CloudToolsPreferencePage;
 
 public class AnalyticsPingManagerTest {
 
@@ -85,16 +99,73 @@ public class AnalyticsPingManagerTest {
 
   @Test
   public void testEventTypeEventNameConvention() {
-    Map<String, String> parameters =
-        AnalyticsPingManager.buildParametersMap("some.event-name", null, null);
+    Map<String, String> parameters = AnalyticsPingManager.buildParametersMap(
+        "clientId", "some.event-name", null, null);
     Assert.assertEquals("/virtual/gcloud-eclipse-tools/some.event-name",
         parameters.get("dp"));
   }
 
   @Test
   public void testMetadataConvention() {
-    Map<String, String> parameters =
-        AnalyticsPingManager.buildParametersMap("some.event-name", "times-happened", "1234");
+    Map<String, String> parameters = AnalyticsPingManager.buildParametersMap(
+        "clientId", "some.event-name", "times-happened", "1234");
     Assert.assertEquals("times-happened=1234", parameters.get("dt"));
+  }
+
+  @Test
+  public void testOptInDialogShown_optInNotRegisteredAndNotYetOptedIn() {
+    IEclipsePreferences preferences = mock(IEclipsePreferences.class);
+    mockOptIn(preferences, false);
+    mockOptInRegistered(preferences, false);
+
+    verifyOptInDialogOpen(preferences, times(1));
+  }
+
+  @Test
+  public void testOptInDialogSkipped_optInNotRegisteredAndAlreadyOptedIn() {
+    IEclipsePreferences preferences = mock(IEclipsePreferences.class);
+    mockOptIn(preferences, true);
+    mockOptInRegistered(preferences, false);
+
+    verifyOptInDialogOpen(preferences, never());
+  }
+
+  @Test
+  public void testOptInDialogSkipped_optInRegisteredAndNotYetOptedIn() {
+    IEclipsePreferences preferences = mock(IEclipsePreferences.class);
+    mockOptIn(preferences, false);
+    mockOptInRegistered(preferences, true);
+
+    verifyOptInDialogOpen(preferences, never());
+  }
+
+  @Test
+  public void testOptInDialogSkipped_optInRegisteredAndAlreadyOptedIn() {
+    IEclipsePreferences preferences = mock(IEclipsePreferences.class);
+    mockOptIn(preferences, true);
+    mockOptInRegistered(preferences, true);
+
+    verifyOptInDialogOpen(preferences, never());
+  }
+
+  private void mockOptIn(IEclipsePreferences preferences, boolean optIn) {
+    when(preferences.getBoolean(eq(CloudToolsPreferencePage.ANALYTICS_OPT_IN), anyBoolean()))
+        .thenReturn(optIn);
+  }
+
+  private void mockOptInRegistered(IEclipsePreferences preferences, boolean registered) {
+    when(preferences.getBoolean(eq(CloudToolsPreferencePage.ANALYTICS_OPT_IN_REGISTERED),
+                                anyBoolean()))
+        .thenReturn(registered);
+  }
+
+  private void verifyOptInDialogOpen(
+      IEclipsePreferences preferences, VerificationMode verificationMode) {
+    OptInDialog optInDialog = mock(OptInDialog.class);
+    OptInDialogCreator dialogCreator = mock(OptInDialogCreator.class);
+    when(dialogCreator.create(any(Shell.class))).thenReturn(optInDialog);
+
+    new AnalyticsPingManager(preferences, dialogCreator).showOptInDialog(new Shell());
+    verify(optInDialog, verificationMode).open();
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -232,6 +232,9 @@ public class AnalyticsPingManager {
     }
   }
 
+  /**
+   * May return null. (However, dialogs can have null as a parent shell.)
+   */
   private Shell findShell(Shell parentShell) {
     if (parentShell != null) {
       return parentShell;
@@ -239,10 +242,15 @@ public class AnalyticsPingManager {
 
     try {
       IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-      return window == null ? null : window.getShell();
+      if (window != null) {
+        return window.getShell();
+      }
     } catch (IllegalStateException ise) {  // getWorkbench() might throw this.
-      return null;
+      // Fall through.
     }
+
+    Display display = Display.getCurrent();
+    return display != null ? display.getActiveShell() : null;
   }
 
   private void flushPreferences() {

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -7,6 +7,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
@@ -223,21 +224,24 @@ public class AnalyticsPingManager {
   }
 
   /**
-   * @param parentShell if null, shows the dialog at the workbench level.
+   * @param parentShell if null, tries to show the dialog at the workbench level.
    */
   public void showOptInDialog(Shell parentShell) {
     if (!hasUserOptedIn() && !hasUserRegisteredOptInStatus()) {
-      if (parentShell != null) {
-        optInDialogCreator.create(parentShell).open();
-      } else {
-        // Show the dialog at the workbench level, if it exists.
-        IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-        if (window != null) {
-          optInDialogCreator.create(window.getShell()).open();
-        } else {
-          logger.log(Level.WARNING, "No active workbench window found.");
-        }
-      }
+      optInDialogCreator.create(findShell(parentShell)).open();
+    }
+  }
+
+  private Shell findShell(Shell parentShell) {
+    if (parentShell != null) {
+      return parentShell;
+    }
+
+    try {
+      IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+      return window == null ? null : window.getShell();
+    } catch (IllegalStateException ise) {  // getWorkbench() might throw this.
+      return null;
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
@@ -15,7 +15,7 @@ import org.eclipse.ui.PlatformUI;
 /**
  * A one-time dialog to suggest opt-in for sending client-side usage metrics.
  */
-class OptInDialog extends Dialog {
+public class OptInDialog extends Dialog {
 
   public OptInDialog(Shell parentShell) {
     super(parentShell);
@@ -73,13 +73,13 @@ class OptInDialog extends Dialog {
   @Override
   protected void okPressed() {
     super.okPressed();
-    AnalyticsPingManager.registerOptInStatus(true);
+    AnalyticsPingManager.getInstance().registerOptInStatus(true);
   }
 
   @Override
   protected void cancelPressed() {
     super.cancelPressed();
-    AnalyticsPingManager.registerOptInStatus(false);
+    AnalyticsPingManager.getInstance().registerOptInStatus(false);
   }
 
   /**
@@ -88,6 +88,6 @@ class OptInDialog extends Dialog {
   @Override
   protected void handleShellCloseEvent() {
     super.handleShellCloseEvent();
-    AnalyticsPingManager.registerOptInStatus(false);
+    AnalyticsPingManager.getInstance().registerOptInStatus(false);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
@@ -24,31 +24,36 @@ public class OptInDialog extends Dialog {
   }
 
   /**
-   * Show this dialog at the top-right corner.
+   * Show this dialog at the top-right corner of some target window.
    */
   @Override
   protected Point getInitialLocation(Point initialSize) {
-    Shell targetShell = null;
-    try {
-      // Prefer showing at the top-right corner of the currently active workbench, but
-      // if we can't get a workbench for any reason, fall back to the parent shell.
-      IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-      targetShell = window != null ? window.getShell() : getParentShell();
-    } catch (IllegalStateException ise) {  // getWorkbench() might throw this.
-      // No special handling. targetShell will be null.
-    }
-
+    Shell targetShell = findTargetShell();
     if (targetShell == null) {
       return super.getInitialLocation(initialSize);
-    } else {
-      // Position the dialog at the top-right corner of the targetShell window.
-      Rectangle parentBounds = targetShell.getBounds();
-      Rectangle parentClientArea = targetShell.getClientArea();
+    }
 
-      int heightCaptionAndUpperBorder =
-          parentBounds.height - parentClientArea.height - targetShell.getBorderWidth();
-      return new Point(parentBounds.x + parentClientArea.width - initialSize.x,
-          parentBounds.y + heightCaptionAndUpperBorder);
+    // Position the dialog at the top-right corner of the targetShell window.
+    Rectangle parentBounds = targetShell.getBounds();
+    Rectangle parentClientArea = targetShell.getClientArea();
+
+    int heightCaptionAndUpperBorder =
+        parentBounds.height - parentClientArea.height - targetShell.getBorderWidth();
+    return new Point(parentBounds.x + parentClientArea.width - initialSize.x,
+        parentBounds.y + heightCaptionAndUpperBorder);
+  }
+
+  /**
+   * Strongly prefer returning the shell of the currently active workbench as a target
+   * window to position the dialog at the top-right corner. If we can't get a workbench
+   * for any reason, fall back to the parent shell (which can be null).
+   */
+  private Shell findTargetShell() {
+    try {
+      IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+      return window != null ? window.getShell() : getParentShell();
+    } catch (IllegalStateException ise) {  // getWorkbench() might throw this.
+      return null;
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
@@ -28,18 +28,28 @@ public class OptInDialog extends Dialog {
    */
   @Override
   protected Point getInitialLocation(Point initialSize) {
-    // Prefer showing at the top-right corner of the currently active workbench, but
-    // if we can't get a workbench for any reason, fall back to the parent shell.
-    IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-    Shell targetShell = window != null ? window.getShell() : getParentShell();
+    Shell targetShell = null;
+    try {
+      // Prefer showing at the top-right corner of the currently active workbench, but
+      // if we can't get a workbench for any reason, fall back to the parent shell.
+      IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+      targetShell = window != null ? window.getShell() : getParentShell();
+    } catch (IllegalStateException ise) {  // getWorkbench() might throw this.
+      // No special handling. targetShell will be null.
+    }
 
-    Rectangle parentBounds = targetShell.getBounds();
-    Rectangle parentClientArea = targetShell.getClientArea();
+    if (targetShell == null) {
+      return super.getInitialLocation(initialSize);
+    } else {
+      // Position the dialog at the top-right corner of the targetShell window.
+      Rectangle parentBounds = targetShell.getBounds();
+      Rectangle parentClientArea = targetShell.getClientArea();
 
-    int heightCaptionAndUpperBorder =
-        parentBounds.height - parentClientArea.height - targetShell.getBorderWidth();
-    return new Point(parentBounds.x + parentClientArea.width - initialSize.x,
-        parentBounds.y + heightCaptionAndUpperBorder);
+      int heightCaptionAndUpperBorder =
+          parentBounds.height - parentClientArea.height - targetShell.getBorderWidth();
+      return new Point(parentBounds.x + parentClientArea.width - initialSize.x,
+          parentBounds.y + heightCaptionAndUpperBorder);
+    }
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
@@ -51,10 +51,13 @@ public class OptInDialog extends Dialog {
   private Shell findTargetShell() {
     try {
       IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-      return window != null ? window.getShell() : getParentShell();
+      if (window != null) {
+        return window.getShell();
+      }
     } catch (IllegalStateException ise) {  // getWorkbench() might throw this.
-      return null;
+      // Fall through.
     }
+    return getParentShell();
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialog.java
@@ -51,13 +51,10 @@ public class OptInDialog extends Dialog {
   private Shell findTargetShell() {
     try {
       IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-      if (window != null) {
-        return window.getShell();
-      }
+      return window != null ? window.getShell() : getParentShell();
     } catch (IllegalStateException ise) {  // getWorkbench() might throw this.
-      // Fall through.
+      return getParentShell();
     }
-    return getParentShell();
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialogCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInDialogCreator.java
@@ -1,0 +1,15 @@
+package com.google.cloud.tools.eclipse.usagetracker;
+
+import org.eclipse.swt.widgets.Shell;
+
+
+/**
+ * The only purpose of the class is to allow unit testing for
+ * {@link AnalyticsPingManager#showOptInDialog}.
+ */
+public class OptInDialogCreator {
+
+  public OptInDialog create(Shell parentShell) {
+    return new OptInDialog(parentShell);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInPopup.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/OptInPopup.java
@@ -9,6 +9,8 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 
 /**
  * A one-time dialog to suggest opt-in for sending client-side usage metrics.
@@ -26,11 +28,16 @@ class OptInDialog extends Dialog {
    */
   @Override
   protected Point getInitialLocation(Point initialSize) {
-    Rectangle parentBounds = getParentShell().getBounds();
-    Rectangle parentClientArea = getParentShell().getClientArea();
+    // Prefer showing at the top-right corner of the currently active workbench, but
+    // if we can't get a workbench for any reason, fall back to the parent shell.
+    IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+    Shell targetShell = window != null ? window.getShell() : getParentShell();
+
+    Rectangle parentBounds = targetShell.getBounds();
+    Rectangle parentClientArea = targetShell.getClientArea();
 
     int heightCaptionAndUpperBorder =
-        parentBounds.height - parentClientArea.height - getParentShell().getBorderWidth();
+        parentBounds.height - parentClientArea.height - targetShell.getBorderWidth();
     return new Point(parentBounds.x + parentClientArea.width - initialSize.x,
         parentBounds.y + heightCaptionAndUpperBorder);
   }


### PR DESCRIPTION
Two enhancements:

- `sendPing()` will show the opt-in dialog (only once) if needed.
- Allows a `sendPing()` caller to set the parent shell of the opt-in dialog.