### PR TITLE
Include the org.eclipse.jst.common.fproj.enablement.jdt.sdk feature

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -12,6 +12,7 @@
 
   <feature id="org.eclipse.jst.web_sdk.feature" version="0.0.0"/>
   <feature id="org.eclipse.jst.server_sdk.feature" version="0.0.0"/>
+  <feature id="org.eclipse.jst.common.fproj.enablement.jdt.sdk" version="0.0.0"/>
   <feature id="org.eclipse.wst.common.fproj.sdk" version="0.0.0"/>
   <feature id="org.eclipse.wst.web_sdk.feature" version="0.0.0"/>
   <feature id="org.eclipse.wst.server_adapters.sdk.feature" version="0.0.0"/>

--- a/eclipse/mars/gcp-eclipse-mars.target
+++ b/eclipse/mars/gcp-eclipse-mars.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Mars" sequenceNumber="1461163382">
+<target name="GCP for Eclipse Mars" sequenceNumber="1467825860">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
@@ -25,6 +25,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.7.1.v201512021921"/>
       <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.200.v201512031711"/>
+      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.6.3.v201501141810"/>
       <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
       <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.7.1.v201602111638"/>
       <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.500.v201508271522"/>

--- a/eclipse/mars/gcp-eclipse-mars.tpd
+++ b/eclipse/mars/gcp-eclipse-mars.tpd
@@ -37,6 +37,7 @@ location "http://download.eclipse.org/releases/mars/" {
 location "http://download.eclipse.org/webtools/repository/mars/" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
+    org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group
     org.eclipse.wst.common.fproj.sdk.feature.group
     org.eclipse.wst.web_sdk.feature.feature.group
     org.eclipse.wst.server_adapters.sdk.feature.feature.group

--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Neon" sequenceNumber="1466656240">
+<target name="GCP for Eclipse Neon" sequenceNumber="1467825837">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
@@ -25,6 +25,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201605120129"/>
       <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201606081655"/>
+      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201603091933"/>
       <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
       <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.8.0.v201606030549"/>
       <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201606081655"/>

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -36,6 +36,7 @@ location "http://download.eclipse.org/releases/neon" {
 location "http://download.eclipse.org/webtools/downloads/drops/R3.8.0/R-3.8.0-20160608130753/repository" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
+    org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group
     org.eclipse.wst.common.fproj.sdk.feature.group
     org.eclipse.wst.web_sdk.feature.feature.group
     org.eclipse.wst.server_adapters.sdk.feature.feature.group


### PR DESCRIPTION
Required for source bundles such as org.eclipse.jst.common.project.facet.core.

With this patch `mvn -Pide-target-platform package` should include the source for `org.eclipse.jst.common.project.facet.core`.

```
$ ls eclipse/ide-target-platform/target/repository/plugins/org.eclipse.jst.common.project.facet.core*
org.eclipse.jst.common.project.facet.core.source_1.4.400.v201403261418.jar
org.eclipse.jst.common.project.facet.core_1.4.400.v201403261418.jar
```