### PR TITLE
Use 0.1.3-SNAPHSOT for appengine-plugins-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
       <!-- bundle: com.google.cloud.tools.app.lib -->
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.1.1-SNAPSHOT</version>
+      <version>0.1.1</version>
     </dependency>
     <dependency>
       <!-- bundle: com.google.guava -->

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
       <!-- bundle: com.google.cloud.tools.app.lib -->
       <groupId>com.google.cloud.tools</groupId>
       <artifactId>appengine-plugins-core</artifactId>
-      <version>0.1.1</version>
+      <version>0.1.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <!-- bundle: com.google.guava -->


### PR DESCRIPTION
The 0.1.1-SHAPSHOT doesn't seem to exist anymore in the Maven Central.