### PR TITLE
Add Archetype selection page to new project wizard

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
@@ -25,13 +25,32 @@ public class MavenArchetypeProjectWizardTest {
   }
 
   @Test
-  public void testOnePage() {
-    Assert.assertEquals(1, wizard.getPageCount());
+  public void testTwoPages() {
+    Assert.assertEquals(2, wizard.getPageCount());
   }
   
   @Test
   public void testGetPageByName() {
-    Assert.assertNotNull(wizard.getPage("basicNewProjectPage"));
+    assertNotNull(wizard.getPage("basicNewProjectPage"));
+    assertNotNull(wizard.getPage("newProjectArchetypePage"));
   }
-  
+
+  @Test
+  public void testPageComplete() {
+    Assert.assertFalse(wizard.getPage("newProjectArchetypePage").isPageComplete());
+    Assert.assertFalse(wizard.getPage("newProjectArchetypePage").isPageComplete());
+  }
+
+  @Test
+  public void testFlipToPageTwo() {
+    Assert.assertFalse(wizard.getPage("basicNewProjectPage").canFlipToNextPage());
+  }
+
+  @Test
+  public void testPageOrder() {
+    Assert.assertEquals(wizard.getPage("newProjectArchetypePage"),
+        wizard.getPage("basicNewProjectPage").getNextPage());
+    Assert.assertEquals(wizard.getPage("basicNewProjectPage"),
+        wizard.getPage("newProjectArchetypePage").getPreviousPage());
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
@@ -53,4 +53,11 @@ public class MavenArchetypeProjectWizardTest {
     Assert.assertEquals(wizard.getPage("basicNewProjectPage"),
         wizard.getPage("newProjectArchetypePage").getPreviousPage());
   }
+
+  @Test
+  public void testArchetypeDefaultSelection() {
+    Assert.assertEquals("appengine-skeleton-archetype",
+        MavenAppEngineStandardArchetypeWizardPage.PRESET_ARCHETYPES.get(0)
+            .archetype.getArtifactId());
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: com.google.cloud.tools.eclipse.appengine.newproject;bundle-versi
  org.eclipse.ui.ide,
  org.eclipse.core.jobs,
  org.eclipse.m2e.core;bundle-version="1.6.2",
- org.eclipse.m2e.core.ui;bundle-version="1.6.2"
+ org.eclipse.m2e.core.ui;bundle-version="1.6.2",
+ com.google.guava
 Bundle-ActivationPolicy: lazy
 Import-Package: com.google.cloud.tools.eclipse.appengine.ui,
  org.apache.maven.archetype.catalog;provider=m2e,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProject.java
@@ -41,6 +41,7 @@ public class CreateMavenBasedAppEngineStandardProject extends WorkspaceModifyOpe
   private String groupId;
   private String version;
   private IPath location;
+  private Archetype archetype;
 
   @Override
   protected void execute(IProgressMonitor monitor)
@@ -68,7 +69,7 @@ public class CreateMavenBasedAppEngineStandardProject extends WorkspaceModifyOpe
     String packageName = this.packageName == null || this.packageName.isEmpty() 
         ? groupId : this.packageName;
     List<IProject> archetypeProjects = projectConfigurationManager.createArchetypeProjects(location,
-        getArchetypeDescriptor(), groupId, artifactId, version, packageName, properties,
+        archetype, groupId, artifactId, version, packageName, properties,
         importConfiguration, progress.newChild(40));
 
     SubMonitor loopMonitor = progress.newChild(30).setWorkRemaining(3 * archetypeProjects.size());
@@ -87,15 +88,6 @@ public class CreateMavenBasedAppEngineStandardProject extends WorkspaceModifyOpe
      */
     Job job = new MappingDiscoveryJob(archetypeProjects);
     job.schedule();
-  }
-
-  @SuppressWarnings("restriction")
-  Archetype getArchetypeDescriptor() {
-    Archetype archetype = new Archetype();
-    archetype.setGroupId("com.google.appengine.archetypes");
-    archetype.setArtifactId("appengine-skeleton-archetype");
-    archetype.setVersion("LATEST");
-    return archetype;
   }
 
   private String resolveLatestReleasedArtifact(SubMonitor progress, String groupId,
@@ -147,5 +139,9 @@ public class CreateMavenBasedAppEngineStandardProject extends WorkspaceModifyOpe
    */
   public void setLocation(IPath location) {
     this.location = location;
+  }
+
+  public void setArchetype(Archetype archetype) {
+    this.archetype = archetype;
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardArchetypeWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardArchetypeWizardPage.java
@@ -1,0 +1,103 @@
+package com.google.cloud.tools.eclipse.appengine.newproject.maven;
+
+import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
+
+import org.apache.maven.archetype.catalog.Archetype;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.wizard.IWizardPage;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.List;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * UI to select an archetype in creating a new Maven-based App Engine Standard Java project.
+ */
+public class MavenAppEngineStandardArchetypeWizardPage extends WizardPage implements IWizardPage {
+
+  private static final java.util.List<ArchetypeTuple> PRESET_ARCHETYPES =
+      Collections.unmodifiableList(Arrays.asList(
+          new ArchetypeTuple("com.google.appengine.archetypes", //$NON-NLS-1$
+              "appengine-skeleton-archetype", //$NON-NLS-1$
+              Messages.getString("APPENGINE_SKELETON_ARCHETYPE_DISPLAY_NAME"), //$NON-NLS-1$
+              Messages.getString("APPENGINE_SKELETON_ARCHETYPE_DESCRIPTION")), //$NON-NLS-1$
+          new ArchetypeTuple("com.google.appengine.archetypes", //$NON-NLS-1$
+              "guestbook-archetype", //$NON-NLS-1$
+              Messages.getString("APPENGINE_GUESTBOOK_ARCHETYPE_DISPLAY_NAME"), //$NON-NLS-1$
+              Messages.getString("APPENGINE_GUESTBOOK_ARCHETYPE_DESCRIPTION")))); //$NON-NLS-1$
+
+  // UI components
+  private List archetypeList;
+  private StyledText descriptionBox;
+
+  public MavenAppEngineStandardArchetypeWizardPage() {
+    super("newProjectArchetypePage"); //$NON-NLS-1$
+    setTitle("Maven-based App Engine Standard Project");
+    setDescription("Select an Archetype");
+    setImageDescriptor(AppEngineImages.googleCloudPlatform(32));
+  }
+
+  @Override
+  public void createControl(Composite parent) {
+    Composite container = new Composite(parent, SWT.NONE);
+    GridLayoutFactory.swtDefaults().numColumns(2).applyTo(container);
+
+    // List of (selectable) archetypes on the left
+    archetypeList = new List(container, SWT.SINGLE | SWT.BORDER);
+    for (ArchetypeTuple tuple : PRESET_ARCHETYPES) {
+      archetypeList.add(tuple.displayName);
+    }
+    archetypeList.setSelection(0);
+    GridDataFactory.defaultsFor(archetypeList).grab(true, true).applyTo(archetypeList);
+    archetypeList.addSelectionListener(new SelectionAdapter() {
+      @Override
+      public void widgetSelected(SelectionEvent event) {
+        int index = archetypeList.getSelectionIndex();
+        descriptionBox.setText(PRESET_ARCHETYPES.get(index).description);
+      }
+    });
+
+    // Text box describing a selected archetype on the right
+    descriptionBox = new StyledText(container, SWT.MULTI | SWT.WRAP | SWT.BORDER | SWT.READ_ONLY);
+    descriptionBox.setText(PRESET_ARCHETYPES.get(0).description);
+    descriptionBox.setEnabled(false);
+    descriptionBox.setMargins(5, 5, 5, 5);
+    GridDataFactory.defaultsFor(descriptionBox).applyTo(descriptionBox);
+
+    setControl(container);
+
+    Dialog.applyDialogFont(container);
+  }
+
+  public Archetype getArchetype() {
+    return PRESET_ARCHETYPES.get(archetypeList.getSelectionIndex()).archetype;
+  }
+
+  @Override
+  public boolean isPageComplete() {
+    return isCurrentPage();
+  }
+
+  private static class ArchetypeTuple {
+    Archetype archetype;
+    String displayName;
+    String description;
+
+    ArchetypeTuple(String groupId, String artifactId, String displayName, String description) {
+      archetype = new Archetype();
+      archetype.setGroupId(groupId);
+      archetype.setArtifactId(artifactId);
+      archetype.setVersion("LATEST"); //$NON-NLS-1$
+      this.displayName = displayName;
+      this.description = description;
+    }
+  };
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardArchetypeWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardArchetypeWizardPage.java
@@ -1,6 +1,7 @@
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
+import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.maven.archetype.catalog.Archetype;
 import org.eclipse.jface.dialogs.Dialog;
@@ -23,7 +24,8 @@ import java.util.Collections;
  */
 public class MavenAppEngineStandardArchetypeWizardPage extends WizardPage implements IWizardPage {
 
-  private static final java.util.List<ArchetypeTuple> PRESET_ARCHETYPES =
+  @VisibleForTesting
+  static final java.util.List<ArchetypeTuple> PRESET_ARCHETYPES =
       Collections.unmodifiableList(Arrays.asList(
           new ArchetypeTuple("com.google.appengine.archetypes", //$NON-NLS-1$
               "appengine-skeleton-archetype", //$NON-NLS-1$
@@ -86,7 +88,8 @@ public class MavenAppEngineStandardArchetypeWizardPage extends WizardPage implem
     return isCurrentPage();
   }
 
-  private static class ArchetypeTuple {
+  @VisibleForTesting
+  static class ArchetypeTuple {
     Archetype archetype;
     String displayName;
     String description;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -44,6 +44,8 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
   private Text versionField;
   private Text javaPackageField;
   private Text projectIdField;
+
+  private boolean canFlipPage;
   
   public MavenAppEngineStandardWizardPage() {
     super("basicNewProjectPage"); //$NON-NLS-1$
@@ -51,7 +53,7 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
     setDescription("Create new Maven-based App Engine Standard Project");
     setImageDescriptor(AppEngineImages.googleCloudPlatform(32));
 
-    setPageComplete(false);
+    canFlipPage = false;
   }
 
   @Override
@@ -107,7 +109,7 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
       public void widgetSelected(SelectionEvent e) {
         locationField.setEnabled(!useDefaults.getSelection());
         locationBrowseButton.setEnabled(!useDefaults.getSelection());
-        checkPageComplete();
+        checkFlipToNext();
       }
     });
   }
@@ -171,12 +173,18 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
     String location = dialog.open();
     if (location != null) {
       locationField.setText(location);
-      checkPageComplete();
+      checkFlipToNext();
     }
   }
 
-  protected void checkPageComplete() {
-    setPageComplete(validatePage());
+  @Override
+  public boolean canFlipToNextPage() {
+    return canFlipPage;
+  }
+
+  protected void checkFlipToNext() {
+    canFlipPage = validatePage();
+    getContainer().updateButtons();
   }
 
   /**
@@ -312,7 +320,7 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
   private final class PageValidator implements ModifyListener {
     @Override
     public void modifyText(ModifyEvent event) {
-      checkPageComplete();
+      checkFlipToNext();
     }
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizard.java
@@ -15,6 +15,7 @@ import java.lang.reflect.InvocationTargetException;
 
 public class MavenArchetypeProjectWizard extends Wizard implements INewWizard {
   private MavenAppEngineStandardWizardPage page;
+  private MavenAppEngineStandardArchetypeWizardPage archetypePage;
 
   public MavenArchetypeProjectWizard() {
     setWindowTitle("New Maven-based App Engine Standard Project");
@@ -24,7 +25,9 @@ public class MavenArchetypeProjectWizard extends Wizard implements INewWizard {
   @Override
   public void addPages() {
     page = new MavenAppEngineStandardWizardPage();
+    archetypePage = new MavenAppEngineStandardArchetypeWizardPage();
     this.addPage(page);
+    this.addPage(archetypePage);
   }
 
   @Override
@@ -38,6 +41,7 @@ public class MavenArchetypeProjectWizard extends Wizard implements INewWizard {
     if (page.useDefaults()) {
       operation.setLocation(page.getLocationPath());
     }
+    operation.setArchetype(archetypePage.getArchetype());
 
     IRunnableWithProgress runnable = new IRunnableWithProgress() {
       @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/Messages.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/Messages.java
@@ -1,0 +1,21 @@
+package com.google.cloud.tools.eclipse.appengine.newproject.maven;
+
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+public class Messages {
+  private static final String BUNDLE_NAME = "com.google.cloud.tools.eclipse.appengine.newproject.maven.messages"; //$NON-NLS-1$
+
+  private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
+
+  private Messages() {
+  }
+
+  public static String getString(String key) {
+    try {
+      return RESOURCE_BUNDLE.getString(key);
+    } catch (MissingResourceException e) {
+      return '!' + key + '!';
+    }
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/messages.properties
@@ -1,0 +1,4 @@
+APPENGINE_GUESTBOOK_ARCHETYPE_DESCRIPTION=Generates the guestbook demo sample, complete and ready to run and test.
+APPENGINE_GUESTBOOK_ARCHETYPE_DISPLAY_NAME=Guestbook example
+APPENGINE_SKELETON_ARCHETYPE_DESCRIPTION=Generates a new, empty App Engine project ready for your own classes and resources, but with required files and directories.
+APPENGINE_SKELETON_ARCHETYPE_DISPLAY_NAME=Hello-world template


### PR DESCRIPTION
Fixes #182.

My take here is to add a second wizard page where a user selects an archetype to use.

I didn't add two Endpoints archetypes since we don't support Endpoints yet. I checked that templates are properly generated for the current two archetypes: skeleton (hello-world) and guestbook.

![archetype-wizard-page](https://cloud.githubusercontent.com/assets/10523105/16700236/e6c4f31c-4526-11e6-8d7b-869ddf9a2fb4.png)
