### PR TITLE
Auto-set package name as groupId in project wizard

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
@@ -1,7 +1,5 @@
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
-import static com.google.cloud.tools.eclipse.appengine.newproject.maven.MavenAppEngineStandardWizardPage.suggestPackageName;
-
 import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.swt.widgets.Display;
@@ -65,22 +63,31 @@ public class MavenArchetypeProjectWizardTest {
 
   @Test
   public void testSuggestPackageName() {
-    Assert.assertEquals("aa.bb", suggestPackageName("aa.bb", ""));
-    Assert.assertEquals("aa.bb.cc.dd", suggestPackageName("aa.bb", "cc.dd"));
+    Assert.assertEquals("aa.bb",
+        MavenAppEngineStandardWizardPage.suggestPackageName("aa.bb", ""));
+    Assert.assertEquals("aa.bb.cc.dd",
+        MavenAppEngineStandardWizardPage.suggestPackageName("aa.bb", "cc.dd"));
 
-    Assert.assertEquals("aa.bb", suggestPackageName("aA.Bb", ""));
-    Assert.assertEquals("aa.bb.cc.dd", suggestPackageName("Aa.Bb", "Cc.DD"));
+    Assert.assertEquals("aA.Bb",
+        MavenAppEngineStandardWizardPage.suggestPackageName("aA.Bb", ""));
+    Assert.assertEquals("Aa.Bb.Cc.DD",
+        MavenAppEngineStandardWizardPage.suggestPackageName("Aa.Bb", "Cc.DD"));
 
-    Assert.assertEquals("aa.bb", suggestPackageName(" a  a\t . b\r b \n", " \t \r  "));
-    Assert.assertEquals("aa.bb.cc.dd", suggestPackageName("  A  a.\tBb", " C  c . D D  "));
+    Assert.assertEquals("aa.bb",
+        MavenAppEngineStandardWizardPage.suggestPackageName(" a  a\t . b\r b \n", " \t \r  "));
+    Assert.assertEquals("Aa.Bb.Cc.DD",
+        MavenAppEngineStandardWizardPage.suggestPackageName("  A  a.\tBb", " C  c . D D  "));
 
-    Assert.assertEquals("aa.bb", suggestPackageName("....aa....bb...", "......"));
-    Assert.assertEquals("aa.bb.cc.dd", suggestPackageName("....aa....bb...", "..cc....dd.."));
+    Assert.assertEquals("aa.bb",
+        MavenAppEngineStandardWizardPage.suggestPackageName("....aa....bb...", "......"));
+    Assert.assertEquals("aa.bb.cc.dd",
+        MavenAppEngineStandardWizardPage.suggestPackageName("....aa....bb...", "..cc....dd.."));
 
-    Assert.assertEquals("aa._01234bb",
-        suggestPackageName("aa`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/._01234bb", ""));
+    Assert.assertEquals("aa._01234bb", MavenAppEngineStandardWizardPage.suggestPackageName(
+        "aa`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/._01234bb", ""));
     Assert.assertEquals("aa._01234bb._c_c_0.dd01234_",
-        suggestPackageName("aa`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/._01234bb",
+        MavenAppEngineStandardWizardPage.suggestPackageName(
+            "aa`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/._01234bb",
             "_c_c_0.dd01234_`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/"));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
@@ -1,5 +1,7 @@
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
+import static com.google.cloud.tools.eclipse.appengine.newproject.maven.MavenAppEngineStandardWizardPage.suggestPackageName;
+
 import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.swt.widgets.Display;
@@ -59,5 +61,26 @@ public class MavenArchetypeProjectWizardTest {
     Assert.assertEquals("appengine-skeleton-archetype",
         MavenAppEngineStandardArchetypeWizardPage.PRESET_ARCHETYPES.get(0)
             .archetype.getArtifactId());
+  }
+
+  @Test
+  public void testSuggestPackageName() {
+    Assert.assertEquals("aa.bb", suggestPackageName("aa.bb", ""));
+    Assert.assertEquals("aa.bb.cc.dd", suggestPackageName("aa.bb", "cc.dd"));
+
+    Assert.assertEquals("aa.bb", suggestPackageName("aA.Bb", ""));
+    Assert.assertEquals("aa.bb.cc.dd", suggestPackageName("Aa.Bb", "Cc.DD"));
+
+    Assert.assertEquals("aa.bb", suggestPackageName(" a  a\t . b\r b \n", " \t \r  "));
+    Assert.assertEquals("aa.bb.cc.dd", suggestPackageName("  A  a.\tBb", " C  c . D D  "));
+
+    Assert.assertEquals("aa.bb", suggestPackageName("....aa....bb...", "......"));
+    Assert.assertEquals("aa.bb.cc.dd", suggestPackageName("....aa....bb...", "..cc....dd.."));
+
+    Assert.assertEquals("aa._01234bb",
+        suggestPackageName("aa`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/._01234bb", ""));
+    Assert.assertEquals("aa._01234bb._c_c_0.dd01234_",
+        suggestPackageName("aa`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/._01234bb",
+            "_c_c_0.dd01234_`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/"));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: com.google.cloud.tools.eclipse.appengine.newproject;bundle-versi
  org.eclipse.core.jobs,
  org.eclipse.m2e.core;bundle-version="1.6.2",
  org.eclipse.m2e.core.ui;bundle-version="1.6.2",
- com.google.guava
+ com.google.guava,
+ org.apache.commons.lang
 Bundle-ActivationPolicy: lazy
 Import-Package: com.google.cloud.tools.eclipse.appengine.ui,
  org.apache.maven.archetype.catalog;provider=m2e,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
@@ -17,8 +17,7 @@ Require-Bundle: com.google.cloud.tools.eclipse.appengine.newproject;bundle-versi
  org.eclipse.core.jobs,
  org.eclipse.m2e.core;bundle-version="1.6.2",
  org.eclipse.m2e.core.ui;bundle-version="1.6.2",
- com.google.guava,
- org.apache.commons.lang
+ com.google.guava
 Bundle-ActivationPolicy: lazy
 Import-Package: com.google.cloud.tools.eclipse.appengine.ui,
  org.apache.maven.archetype.catalog;provider=m2e,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -377,9 +377,9 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
   /**
    * Helper function returning a suggested package name based on groupId and artifactId.
    *
-   * For an invalid Java package name, it does basic string filtering/manipulation, which
-   * does not completely eliminate name issues. However, users will be alerted of any
-   * slipping errors in naming by {@link #validatePage}.
+   * It does basic string filtering/manipulation, which does not completely eliminate
+   * naming issues. However, users will be alerted of any slipping errors in naming by
+   * {@link #validatePage}.
    */
   @VisibleForTesting
   protected static String suggestPackageName(String groupId, String artifactId) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -383,6 +383,15 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
    */
   @VisibleForTesting
   protected static String suggestPackageName(String groupId, String artifactId) {
+    String naivePackageName = groupId;
+    if (!artifactId.trim().isEmpty()) {
+      naivePackageName = groupId + "." + artifactId;
+    }
+
+    if (JavaPackageValidator.validate(naivePackageName).isOK()) {
+      return naivePackageName;
+    }
+
     // 1) Remove leading and trailing dots.
     // 2) Keep only word characters ([a-zA-Z_0-9]) and dots (escaping inside [] not necessary).
     // 3) Replace consecutive dots with a single dot.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -4,8 +4,9 @@ import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectIdVal
 import com.google.cloud.tools.eclipse.appengine.newproject.JavaPackageValidator;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Strings;
 
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
@@ -374,23 +375,24 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
   }
 
   /**
-   * Helper function returning a suggested package name based on groupId and artifactId. It
-   * does basic string filtering/manipulation for valid Java package names, which is not perfect.
-   * However, users will be alerted of any slipping errors in naming by {@link #validatePage}.
+   * Helper function returning a suggested package name based on groupId and artifactId.
+   *
+   * For an invalid Java package name, it does basic string filtering/manipulation, which
+   * does not completely eliminate name issues. However, users will be alerted of any
+   * slipping errors in naming by {@link #validatePage}.
    */
   @VisibleForTesting
   protected static String suggestPackageName(String groupId, String artifactId) {
     // 1) Remove leading and trailing dots.
     // 2) Keep only word characters ([a-zA-Z_0-9]) and dots (escaping inside [] not necessary).
     // 3) Replace consecutive dots with a single dot.
-    // 4) Lower-case.
-    groupId = StringUtils.strip(groupId, ".")
-        .replaceAll("[^\\w.]", "").replaceAll("\\.+",  ".").toLowerCase();
-    artifactId = StringUtils.strip(artifactId, ".")
-        .replaceAll("[^\\w.]", "").replaceAll("\\.+",  ".").toLowerCase();
+    groupId = CharMatcher.is('.').trimFrom(groupId)
+        .replaceAll("[^\\w.]", "").replaceAll("\\.+",  ".");
+    artifactId = CharMatcher.is('.').trimFrom(artifactId)
+        .replaceAll("[^\\w.]", "").replaceAll("\\.+",  ".");
 
     if (!artifactId.isEmpty()) {  // No whitespace at all, so isEmpty() works.
-      return groupId.toLowerCase() + "." + artifactId.toLowerCase();
+      return groupId + "." + artifactId;
     }
     return groupId;
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -339,6 +339,8 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
     public void verifyText(VerifyEvent event) {
       Text textField = (Text) event.widget;
       String oldText = textField.getText().trim();
+      // Below explains how to get text after modification:
+      // http://stackoverflow.com/questions/32872249/get-text-of-swt-text-component-before-modification
       String newText =
           oldText.substring(0, event.start) + event.text + oldText.substring(event.end);
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -128,6 +128,12 @@ public class MavenAppEngineStandardWizardPage extends WizardPage implements IWiz
     groupIdField = new Text(mavenCoordinatesGroup, SWT.BORDER);
     GridDataFactory.defaultsFor(groupIdField).align(SWT.FILL, SWT.CENTER).applyTo(groupIdField);
     groupIdField.addModifyListener(pageValidator);
+    groupIdField.addModifyListener(new ModifyListener() {
+      @Override
+      public void modifyText(ModifyEvent event) {
+        javaPackageField.setText(groupIdField.getText());
+      }
+    });
 
     Label artifactIdLabel = new Label(mavenCoordinatesGroup, SWT.NONE);
     artifactIdLabel.setText("Artifact Id:"); //$NON-NLS-1$


### PR DESCRIPTION
Fixes #229.

#229 mentions "groupId.artifactId", but the label in the wizard page says "Java package: (defaults to group ID)". For now, I just set it to groupId, since I believe artifactId usually contains hyphens.