### PR TITLE
Fix NPE from Cloud Sdk directory field validation

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/CloudSdkRuntimeWizardFragment.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/CloudSdkRuntimeWizardFragment.java
@@ -65,7 +65,8 @@ public final class CloudSdkRuntimeWizardFragment extends WizardFragment {
     wizard.setTitle("New " + title + " Runtime");
     wizard.setDescription("Define a new " + title + " runtime");
 
-    // Before createContents(), as createContents() may set the dirTextBox, triggering validation
+    // Do this before createContents() to prevent NPE; createContents() may set the dirTextBox,
+    // triggering validation
     configureValidationJob();
 
     Composite composite = new Composite(parent, SWT.NONE);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/CloudSdkRuntimeWizardFragment.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/CloudSdkRuntimeWizardFragment.java
@@ -65,11 +65,12 @@ public final class CloudSdkRuntimeWizardFragment extends WizardFragment {
     wizard.setTitle("New " + title + " Runtime");
     wizard.setDescription("Define a new " + title + " runtime");
 
+    configureValidationJob();
+
     Composite composite = new Composite(parent, SWT.NONE);
     composite.setLayout(new GridLayout());
     createContents(composite);
 
-    configureValidationJob();
     return composite;
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/CloudSdkRuntimeWizardFragment.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/CloudSdkRuntimeWizardFragment.java
@@ -65,6 +65,7 @@ public final class CloudSdkRuntimeWizardFragment extends WizardFragment {
     wizard.setTitle("New " + title + " Runtime");
     wizard.setDescription("Define a new " + title + " runtime");
 
+    // Before createContents(), as createContents() may set the dirTextBox, triggering validation
     configureValidationJob();
 
     Composite composite = new Composite(parent, SWT.NONE);


### PR DESCRIPTION
Fixes #337.

`configureValidationJob` also depends on the `dirTextBox` field that's triggering the NPE, but `configureValidationJob` checks if the field is initialized currently, so no more problem.