### PR TITLE
Do not include maven metafiles in Tycho-generated artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,17 @@
         </plugin>
 
         <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-packaging-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <archive>
+              <addMavenDescriptor>false</addMavenDescriptor>
+            </archive>
+          </configuration>
+        </plugin>
+
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>1.4.1</version>


### PR DESCRIPTION
Here's a patch to avoid including the Maven metafiles in the generated bundles.  These metafiles are normally included in most Maven-produced jars, including our own `app-tools-lib-for-java`, so I'm not sure this is a real win.

Fixes #341 