### PR TITLE
Verify that our feature can be installed with no missing dependencies

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.tools.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  <artifactId>build</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+</project>

--- a/build/verify-feature-completeness/pom.xml
+++ b/build/verify-feature-completeness/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.tools.eclipse</groupId>
+    <artifactId>build</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>verify-feature-completeness</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Installation Testing for GCP</name>
+  <description>
+    Attempt to install the main features with an Eclipse installation
+    to ensure that our feature definitions are complete.
+  </description>
+
+  <properties>
+    <installIUs>org.eclipse.platform.feature.group,com.google.cloud.tools.eclipse.suite.e45.feature.feature.group</installIUs>
+    <build.rootUri>${project.baseUri}/../..</build.rootUri>
+    <eclipse.repoUrl>${build.rootUri}/eclipse/ide-target-platform/target/repository</eclipse.repoUrl>
+    <gcp.repoUrl>${build.rootUri}/gcp-repo/target/repository</gcp.repoUrl>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud.tools.eclipse</groupId>
+      <artifactId>ide-target-platform.repo</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <type>eclipse-repository</type>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools.eclipse</groupId>
+      <artifactId>google-cloud-plugin-eclipse.repo</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <type>eclipse-repository</type>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- force a clean to remove any existing installation -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>2.5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho.extras</groupId>
+        <artifactId>tycho-eclipserun-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <argLine>-Declipse.p2.mirrors=false</argLine>
+          <appArgLine>
+            -consoleLog -nosplash
+            -application org.eclipse.equinox.p2.director
+            -destination ${project.build.directory}/p2-installation
+            -repository ${eclipse.repoUrl},${gcp.repoUrl} 
+            -installIUs ${installIUs}
+          </appArgLine>
+          <repositories>
+            <repository>
+              <id>juno</id>
+              <layout>p2</layout>
+              <url>${eclipse.repoUrl}</url>
+            </repository>
+          </repositories>
+          <dependencies>
+            <dependency>
+              <artifactId>org.eclipse.equinox.p2.transport.ecf</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+            <dependency>
+              <artifactId>org.eclipse.equinox.p2.repository</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+            <dependency>
+              <artifactId>org.eclipse.equinox.p2.touchpoint.natives</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+            <dependency>
+              <artifactId>org.eclipse.equinox.p2.touchpoint.eclipse</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+            <dependency>
+              <artifactId>org.eclipse.equinox.p2.artifact.repository</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+            <dependency>
+              <artifactId>org.eclipse.equinox.p2.director.app</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+            <dependency>
+              <artifactId>org.eclipse.equinox.simpleconfigurator</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+            <dependency>
+              <artifactId>org.eclipse.osgi.compatibility.state</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+            <dependency>
+              <artifactId>org.eclipse.equinox.ds</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+            <dependency>
+              <artifactId>org.eclipse.core.net</artifactId>
+              <type>eclipse-plugin</type>
+            </dependency>
+          </dependencies>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>eclipse-run</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  </project>

--- a/build/verify-feature-completeness/pom.xml
+++ b/build/verify-feature-completeness/pom.xml
@@ -71,7 +71,7 @@
           </appArgLine>
           <repositories>
             <repository>
-              <id>juno</id>
+              <id>eclipse</id>
               <layout>p2</layout>
               <url>${eclipse.repoUrl}</url>
             </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,10 @@
         <!-- Ensure we don't resolved mis-cached artifacts -->
         <tycho.localArtifacts>ignore</tycho.localArtifacts>
       </properties>
+      <modules>
+        <module>eclipse/ide-target-platform</module>
+        <module>build/verify-feature-completeness</module>
+      </modules>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
       </activation>
       <properties>
          <jettyMinVersion>9.1</jettyMinVersion>
-          <jettyMaxVersion>9.3</jettyMaxVersion>
+         <jettyMaxVersion>9.3</jettyMaxVersion>
       </properties>
       <!-- build against a known target platform -->
       <modules>
@@ -264,8 +264,8 @@
         </property>
       </activation>
       <properties>
-         <jettyMinVersion>9.1</jettyMinVersion>
-         <jettyMaxVersion>9.3</jettyMaxVersion>
+         <jettyMinVersion>9.3</jettyMinVersion>
+         <jettyMaxVersion>9.4</jettyMaxVersion>
       </properties>
       <!-- build against a known target platform -->
       <modules>
@@ -308,7 +308,7 @@
       <properties>
         <!-- We configure Travis to use jdk7 -->
         <tycho.toolchains>SYSTEM</tycho.toolchains>
-        <!-- Ensure we don't resolved mis-cached artifacts -->
+        <!-- Ensure we don't resolve previous versions of our artifacts -->
         <tycho.localArtifacts>ignore</tycho.localArtifacts>
       </properties>
       <modules>


### PR DESCRIPTION
Add new test for Travis build that attempts to install the
com.google.cloud.tools.eclipse.suite.e45.feature and fails on any
missing dependencies.

Enabled for Travis builds only (i.e., `mvn -Ptravis package`).

Fixes #351 