### PR TITLE
remove app-tools-lib-for-java from assorted names

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.properties
@@ -7,10 +7,10 @@ runtimeTypeDescription=Google App Engine Standard Runtime (Custom)
 runtimeTypeName=App Engine Standard (Custom)
 runtimeTypeVendor=Google
 
-apptoolsTypeDescription=Google App Engine Standard Runtime (app-tools-lib-for-java)
-apptoolsTypeName=App Engine Standard (app-tools-lib-for-java)
-apptoolsRuntimeTypeName=App Engine Standard Runtime (app-tools-lib-for-java)
-apptoolsServerTypeName=App Engine Local Server (app-tools-lib-for-java)
+apptoolsTypeDescription=Google App Engine Standard Runtime
+apptoolsTypeName=App Engine Standard
+apptoolsRuntimeTypeName=App Engine Standard Runtime
+apptoolsServerTypeName=App Engine Local Server
+serverTypeDescription=Local development server for Google App Engine Standard Environment
 
 customServerTypeName=App Engine Standard (Custom)
-serverTypeDescription=Local development server for Google App Engine Standard Environment

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferencePage.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferencePage.java
@@ -103,7 +103,7 @@ public class CloudSdkPreferencePage extends FieldEditorPreferencePage
 
   protected boolean validateSdk(File location) {
     try {
-      CloudSdk sdk = new CloudSdk.Builder().sdkPath(location).build();
+      CloudSdk sdk = new CloudSdk.Builder().sdkPath(location.toPath()).build();
       sdk.validate();
     } catch (AppEngineException ex) {
       // accept a seemingly invalid location in case the SDK organization

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkProvider.java
@@ -82,7 +82,7 @@ public class CloudSdkProvider extends ContextFunction {
     if (location == null || !location.exists()) {
       return null;
     }
-    return new CloudSdk.Builder().sdkPath(location);
+    return new CloudSdk.Builder().sdkPath(location.toPath());
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkProvider.java
@@ -96,7 +96,7 @@ public class CloudSdkProvider extends ContextFunction {
     if (value != null && !value.isEmpty()) {
       return new File(value);
     }
-    Path discovered = PathResolver.INSTANCE.getCloudSdkPath();
+    Path discovered = new PathResolver().getCloudSdkPath();
     if (discovered != null) {
       return discovered.toFile();
     }

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/PreferenceInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/PreferenceInitializer.java
@@ -24,7 +24,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 
   @Override
   public void initializeDefaultPreferences() {
-    Path path = PathResolver.INSTANCE.getCloudSdkPath();
+    Path path = new PathResolver().getCloudSdkPath();
     DefaultScope.INSTANCE.getNode(BUNDLEID).put(PreferenceConstants.CLOUDSDK_PATH,
         path == null ? "" : path.toString());
   }


### PR DESCRIPTION
I.e. App Engine Standard (app-tools-lib-for-java) is now just App Engine Standard

#313 