### PR TITLE
Set OAuth client ID and client secret at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ hard-coding these values and hamper their public visibilty.
 | Constant                     | Bundle        | System Property       |
 | ---------------------------- | ------------- | --------------------- |
 | OAuth client ID              | login         | `oauth.client.id`     |
-| OAuth client secert          | login         | `oauth.client.secret` |
+| OAuth client secret          | login         | `oauth.client.secret` |
 | Google Analytics Tracking ID | usagetracking | `ga.tracking.id`      |
 
 The Java classes that hold these constant values are auto-generated
@@ -255,7 +255,7 @@ from template Java source files, using [templating-maven-plugin]
 populated from system properties in the auto-gen process. That is, for
 example, `mvn -Doauth.client.id=id1234 templating:filter-sources` or
 `mvn -Doauth.client.id=id1234 package` will result in injecting `id1234`
-as a OAuth client ID.
+as an OAuth client ID.
 
 ### Injecting Constants for Debugging
 

--- a/README.md
+++ b/README.md
@@ -236,4 +236,30 @@ the identifiers are not p2 identifiers, and so features do not
 require the `.feature.group` suffix.
 
 
+# Release
 
+## Compile-time Constant Injection
+
+We plug a few constants into code at compile-time.  We do this to avoid
+hard-coding these values and hamper their public visibilty.
+
+| Constant                     | Bundle        | System Property       |
+| ---------------------------- | ------------- | --------------------- |
+| OAuth client ID              | login         | `oauth.client.id`     |
+| OAuth client secert          | login         | `oauth.client.secret` |
+| Google Analytics Tracking ID | usagetracking | `ga.tracking.id`      |
+
+The Java classes that hold these constant values are auto-generated
+from template Java source files, using [templating-maven-plugin]
+(http://www.mojohaus.org/templating-maven-plugin/).  The values are
+populated from system properties in the auto-gen process. That is, for
+example, `mvn -Doauth.client.id=id1234 templating:filter-sources` or
+`mvn -Doauth.client.id=id1234 package` will result in injecting `id1234`
+as a OAuth client ID.
+
+### Injecting Constants for Debugging
+
+You can also easily inject values for an Eclipse debug session, since Eclipse
+auto-generates the Java classes (if configured to do auto-build).  Providing
+relevant system properties when launching a dev instance of Eclipse and deleting
+a file to re-generate will do the job.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/.classpath
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/.classpath
@@ -2,7 +2,8 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="generated-sources"/>
 	<classpathentry kind="lib" path="lib/google-oauth-client-1.22.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: com.google.cloud.tools.app.lib;bundle-version="0.1.0",
  com.google.gson,
  com.google.guava;bundle-version="15.0.0",
+ org.eclipse.core.runtime,
  org.eclipse.jdt.core,
  org.eclipse.ui
 Bundle-Classpath: lib/google-oauth-client-1.22.0.jar,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/build.properties
@@ -1,5 +1,7 @@
-source.. = src/
-output.. = target/classes/
+source.. = src/,\
+           generated-sources/
+output.. = target/classes/,\
+           bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/build.properties
@@ -1,7 +1,6 @@
 source.. = src/,\
            generated-sources/
-output.. = target/classes/,\
-           bin/
+output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/java-templates/com/google/cloud/tools/eclipse/appengine/login/Constants.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/java-templates/com/google/cloud/tools/eclipse/appengine/login/Constants.java
@@ -1,10 +1,28 @@
 package com.google.cloud.tools.eclipse.appengine.login;
 
+import org.eclipse.core.runtime.Platform;
+
 /**
  * Placeholder constants initialized at compile-time.
  */
 public class Constants {
 
-  public static final String OAUTH_CLIENT_ID = "@oauth.client.id@";
-  public static final String OAUTH_CLIENT_SECRET = "@oauth.client.secret@";
+  private static final String OAUTH_CLIENT_ID = "@oauth.client.id@";
+  private static final String OAUTH_CLIENT_SECRET = "@oauth.client.secret@";
+
+  public static String getOAuthClientId() {
+    if (Platform.inDevelopmentMode()) {
+      return System.getProperty("oauth.client.id", "(unset:oauth.client.id)");
+    } else {
+      return OAUTH_CLIENT_ID;
+    }
+  }
+
+  public static String getOAuthClientSecret() {
+    if (Platform.inDevelopmentMode()) {
+      return System.getProperty("oauth.client.secret", "(unset:oauth.client.secret)");
+    } else {
+      return OAUTH_CLIENT_SECRET;
+    }
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/java-templates/com/google/cloud/tools/eclipse/appengine/login/Constants.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/java-templates/com/google/cloud/tools/eclipse/appengine/login/Constants.java
@@ -1,5 +1,8 @@
 package com.google.cloud.tools.eclipse.appengine.login;
 
+/**
+ * Placeholder constants initialized at compile-time.
+ */
 public class Constants {
 
   public static final String OAUTH_CLIENT_ID = "@oauth.client.id@";

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/java-templates/com/google/cloud/tools/eclipse/appengine/login/Constants.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/java-templates/com/google/cloud/tools/eclipse/appengine/login/Constants.java
@@ -1,0 +1,7 @@
+package com.google.cloud.tools.eclipse.appengine.login;
+
+public class Constants {
+
+  public static final String OAUTH_CLIENT_ID = "@oauth.client.id@";
+  public static final String OAUTH_CLIENT_SECRET = "@oauth.client.secret@";
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/pom.xml
@@ -12,5 +12,26 @@
   <artifactId>com.google.cloud.tools.eclipse.appengine.login</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
-        
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <configuration>
+          <sourceDirectory>${basedir}/java-templates</sourceDirectory>
+          <outputDirectory>${basedir}/generated-sources</outputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginService.java
@@ -28,12 +28,6 @@ import com.google.api.client.auth.oauth2.Credential;
  */
 public class GoogleLoginService {
 
-  // TODO(chanseok): these constant values should be set at compile-time to hide actual values.
-  // For this purpose, we could use org.codehaus.mojo:templating-maven-plugin as in the
-  // .eclipse.usagetracker bundle.
-  public static final String OAUTH_CLIENT_ID = "@oauth.client.id@";
-  public static final String OAUTH_CLIENT_SECRET = "@oauth.client.secret@";
-
   // TODO(chanseok): this will be needed later.
   public static final List<String> OAUTH_SCOPES = Collections.unmodifiableList(Arrays.asList(
       "https://www.googleapis.com/auth/userinfo#email"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginTemporaryTester.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginTemporaryTester.java
@@ -54,8 +54,8 @@ public class GoogleLoginTemporaryTester {
     }
 
     Map<String, String> credentialMap = new HashMap<>();
-    credentialMap.put(CLIENT_ID_LABEL, GoogleLoginService.OAUTH_CLIENT_ID);
-    credentialMap.put(CLIENT_SECRET_LABEL, GoogleLoginService.OAUTH_CLIENT_SECRET);
+    credentialMap.put(CLIENT_ID_LABEL, Constants.OAUTH_CLIENT_ID);
+    credentialMap.put(CLIENT_SECRET_LABEL, Constants.OAUTH_CLIENT_SECRET);
     credentialMap.put(REFRESH_TOKEN_LABEL, credential.getRefreshToken());
     credentialMap.put(GCLOUD_USER_TYPE_LABEL, GCLOUD_USER_TYPE);
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginTemporaryTester.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginTemporaryTester.java
@@ -54,8 +54,8 @@ public class GoogleLoginTemporaryTester {
     }
 
     Map<String, String> credentialMap = new HashMap<>();
-    credentialMap.put(CLIENT_ID_LABEL, Constants.OAUTH_CLIENT_ID);
-    credentialMap.put(CLIENT_SECRET_LABEL, Constants.OAUTH_CLIENT_SECRET);
+    credentialMap.put(CLIENT_ID_LABEL, Constants.getOAuthClientId());
+    credentialMap.put(CLIENT_SECRET_LABEL, Constants.getOAuthClientSecret());
     credentialMap.put(REFRESH_TOKEN_LABEL, credential.getRefreshToken());
     credentialMap.put(GCLOUD_USER_TYPE_LABEL, GCLOUD_USER_TYPE);
 


### PR DESCRIPTION
For #342.

Set client ID and client secret at compile-time by auto-generating `Constants.java` with `templating-maven-plugin`. (The same mechanism as in the `.eclipse.usagetracker` bundle.)