### PR TITLE
Restore CloudSdkProvider#createBuilder()

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
@@ -1,5 +1,13 @@
 package com.google.cloud.tools.eclipse.appengine.deploy.standard;
 
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
+import com.google.cloud.tools.eclipse.appengine.deploy.AppEngineProjectDeployer;
+import com.google.cloud.tools.eclipse.appengine.deploy.Messages;
+import com.google.cloud.tools.eclipse.sdk.CloudSdkProvider;
+import com.google.cloud.tools.eclipse.util.MessageConsoleUtilities;
+import com.google.common.base.Preconditions;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
@@ -10,13 +18,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.ui.console.MessageConsole;
 import org.eclipse.ui.console.MessageConsoleStream;
-
-import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
-import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
-import com.google.cloud.tools.eclipse.appengine.deploy.AppEngineProjectDeployer;
-import com.google.cloud.tools.eclipse.appengine.deploy.Messages;
-import com.google.cloud.tools.eclipse.util.MessageConsoleUtilities;
-import com.google.common.base.Preconditions;
 
 /**
  * Executes a job that deploys a project to App Engine Standard.
@@ -85,7 +86,7 @@ public class StandardDeployJob extends WorkspaceJob {
     MessageConsole messageConsole =
         MessageConsoleUtilities.getMessageConsole(CONSOLE_NAME, null, true /* show */);
     final MessageConsoleStream outputStream = messageConsole.newMessageStream();
-    CloudSdk cloudSdk = new CloudSdk.Builder()
+    CloudSdk cloudSdk = new CloudSdkProvider().createBuilder()
         .addStdErrLineListener(new ProcessOutputLineListener() {
 
           @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -1,9 +1,16 @@
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.appengine.api.devserver.AppEngineDevServer;
+import com.google.cloud.tools.appengine.api.devserver.DefaultRunConfiguration;
+import com.google.cloud.tools.appengine.api.devserver.DefaultStopConfiguration;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
+import com.google.cloud.tools.appengine.cloudsdk.process.ProcessExitListener;
+import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
+import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
+import com.google.cloud.tools.eclipse.sdk.CloudSdkProvider;
+
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -14,15 +21,10 @@ import org.eclipse.wst.server.core.model.IModuleResource;
 import org.eclipse.wst.server.core.model.IModuleResourceDelta;
 import org.eclipse.wst.server.core.model.ServerBehaviourDelegate;
 
-import com.google.cloud.tools.appengine.api.AppEngineException;
-import com.google.cloud.tools.appengine.api.devserver.AppEngineDevServer;
-import com.google.cloud.tools.appengine.api.devserver.DefaultRunConfiguration;
-import com.google.cloud.tools.appengine.api.devserver.DefaultStopConfiguration;
-import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
-import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer;
-import com.google.cloud.tools.appengine.cloudsdk.process.ProcessExitListener;
-import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
-import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * A {@link ServerBehaviourDelegate} for App Engine Server executed via the Java App Management
@@ -164,7 +166,7 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
     LocalAppEngineOutputLineListener outputListener =
         new LocalAppEngineOutputLineListener(stream);
 
-    CloudSdk cloudSdk = new CloudSdk.Builder()
+    CloudSdk cloudSdk = new CloudSdkProvider().createBuilder()
         .addStdOutLineListener(outputListener)
         .addStdErrLineListener(outputListener)
         .startListener(localAppEngineStartListener)

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkContextFunctionTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkContextFunctionTest.java
@@ -73,10 +73,10 @@ public class CloudSdkContextFunctionTest {
     Object instance = function.compute(context, CloudSdk.class.getName());
     assertNotNull(instance);
     assertEquals(CloudSdk.class, instance.getClass());
-    assertEquals(mockSdk, ReflectionUtil.getField(instance, "sdkPath", Path.class));
+    assertEquals(mockSdk, ((CloudSdk) instance).getSdkPath());
   }
 
-  @Ignore
+  @Ignore("affected from changes in global state")
   public void testContextFunctionReinvoked() throws Exception {
     context.set(PreferenceConstants.CLOUDSDK_PATH, "path/does/not/exist");
     CloudSdk instance = context.get(CloudSdk.class);

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkProvider.java
@@ -49,27 +49,37 @@ public class CloudSdkProvider {
   }
 
   /**
+   * Return a {@link CloudSdk.Builder} instance, suitable for creating a {@link CloudSdk} instance
+   * using the configured location if set.
+   * 
+   * @return a builder, or {@code null} if the Google Cloud SDK cannot be located
+   */
+  public CloudSdk.Builder createBuilder() {
+    CloudSdk.Builder sdkBuilder = new CloudSdk.Builder();
+    String configuredPath = preferences.getString(PreferenceConstants.CLOUDSDK_PATH);
+
+    if (configuredPath != null && !configuredPath.isEmpty()) {
+      sdkBuilder.sdkPath(Paths.get(configuredPath));
+    }
+    return sdkBuilder;
+  }
+
+  /**
    * Return the {@link CloudSdk} instance from the configured or discovered Cloud SDK.
    * 
-   * <p>It searches for Cloud SDK in {@code location} first. If Cloud SDK isn't there, it searches
-   * for a valid location in {@code preferences}. If no valid location is found there, we let the
+   * <p>
+   * It searches for Cloud SDK in {@code location} first. If Cloud SDK isn't there, it searches for
+   * a valid location in {@code preferences}. If no valid location is found there, we let the
    * library discover the SDK in its typical locations.
    * 
-   * <p>This method ensures that the return SDK is valid, i.e., it contains the most important
-   * files, or that no SDK is returned.
+   * <p>
+   * This method ensures that the return SDK is valid, i.e., it contains the most important files,
+   * or that no SDK is returned.
    * 
    * @return the configured {@link CloudSdk} or {@code null} if no valid SDK could be found
    */
   public CloudSdk getCloudSdk() {
-    CloudSdk.Builder sdkBuilder = new CloudSdk.Builder();
-    
-    String configuredPath = preferences.getString(PreferenceConstants.CLOUDSDK_PATH);
-    
-    if (location != null) {
-      sdkBuilder.sdkPath(location);
-    } else if (configuredPath != null && !configuredPath.isEmpty()) {
-      sdkBuilder.sdkPath(Paths.get(configuredPath));
-    }
+    CloudSdk.Builder sdkBuilder = createBuilder();
     // If no location is set, let library discover the location.
     
     try {

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkProvider.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.sdk;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk.Builder;
 import com.google.cloud.tools.eclipse.sdk.internal.PreferenceConstants;
 import com.google.cloud.tools.eclipse.sdk.internal.PreferenceInitializer;
 import com.google.common.annotations.VisibleForTesting;
@@ -55,14 +56,22 @@ public class CloudSdkProvider {
    * @return a builder, or {@code null} if the Google Cloud SDK cannot be located
    */
   public CloudSdk.Builder createBuilder() {
-    CloudSdk.Builder sdkBuilder = new CloudSdk.Builder();
-    String configuredPath = preferences.getString(PreferenceConstants.CLOUDSDK_PATH);
+    return createBuilder(location);
+  }
 
-    if (configuredPath != null && !configuredPath.isEmpty()) {
-      sdkBuilder.sdkPath(Paths.get(configuredPath));
+  private Builder createBuilder(Path location) {
+    CloudSdk.Builder sdkBuilder = new CloudSdk.Builder();
+    if (location != null) {
+      sdkBuilder.sdkPath(location);
+    } else {
+      String configuredPath = preferences.getString(PreferenceConstants.CLOUDSDK_PATH);
+      if (configuredPath != null && !configuredPath.isEmpty()) {
+        sdkBuilder.sdkPath(Paths.get(configuredPath));
+      }
     }
     return sdkBuilder;
   }
+
 
   /**
    * Return the {@link CloudSdk} instance from the configured or discovered Cloud SDK.
@@ -79,13 +88,11 @@ public class CloudSdkProvider {
    * @return the configured {@link CloudSdk} or {@code null} if no valid SDK could be found
    */
   public CloudSdk getCloudSdk() {
-    CloudSdk.Builder sdkBuilder = createBuilder();
+    CloudSdk.Builder sdkBuilder = createBuilder(location);
     // If no location is set, let library discover the location.
     
     try {
-      CloudSdk sdk = sdkBuilder.build();
-      sdk.validate();
-      return sdk;
+      return sdkBuilder.build();
     } catch (AppEngineException aee) {
       // If no SDK could be discovered, let the caller prompt the user for a new one.
       return null;

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/PreferenceInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/PreferenceInitializer.java
@@ -27,7 +27,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
     CloudSdk sdk = null;
     try {
       sdk = new CloudSdkProvider().getCloudSdk();
-    } catch(AppEngineException aee) {
+    } catch (AppEngineException aee) {
       // No SDK could be found.
     }
     


### PR DESCRIPTION
Until https://github.com/GoogleCloudPlatform/app-tools-lib-for-java/pull/168 and #362 and fixed, we must continue to use `CloudSdkProvider#createBuilder()` to create and configure `Cloudsdk.Builder` instances.