### PR TITLE
Fix new project setup to reference appengine-api.jar, and point to the online javadocs.

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineSdkClasspathContainer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineSdkClasspathContainer.java
@@ -5,6 +5,7 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaCore;
@@ -13,7 +14,9 @@ public final class AppEngineSdkClasspathContainer implements IClasspathContainer
 
   public static final String CONTAINER_ID = "AppEngineSDK";
 
-  private static final String TOOLS_JAR_NAME = "appengine-tools-api.jar";
+  private static final String API_JAR = "impl/appengine-api.jar";
+  private static final String API_JAVADOC_URL =
+      "https://cloud.google.com/appengine/docs/java/javadoc/";
 
   @Override
   public IPath getPath() {
@@ -35,16 +38,20 @@ public final class AppEngineSdkClasspathContainer implements IClasspathContainer
     try {
       CloudSdk cloudSdk = new CloudSdk.Builder().build();
       if (cloudSdk != null) {
-        java.nio.file.Path jarFile = cloudSdk.getJarPath(TOOLS_JAR_NAME);
+        java.nio.file.Path jarFile = cloudSdk.getJavaAppEngineSdkPath().resolve(API_JAR);
         if (jarFile != null) {
           //@formatter:off
-          IClasspathEntry appEngineToolsEntry = JavaCore.newLibraryEntry(
+          IClasspathAttribute javadocAttribute = 
+              JavaCore.newClasspathAttribute(IClasspathAttribute.JAVADOC_LOCATION_ATTRIBUTE_NAME, API_JAVADOC_URL);
+          IClasspathEntry appEngineApisEntry = JavaCore.newLibraryEntry(
               new Path(jarFile.toString()),
               null /* sourceAttachmentPath */,
-              null /* sourceAttachmentRootPath */, 
+              null /* sourceAttachmentRootPath */,
+              null /* accessRules */,
+              new IClasspathAttribute[] { javadocAttribute },
               true /* isExported */);
           //@formatter:on
-          return new IClasspathEntry[] {appEngineToolsEntry};
+          return new IClasspathEntry[] {appEngineApisEntry};
         }
       }
     } catch (AppEngineException ex) {


### PR DESCRIPTION
`appengine-tools-api.jar` isn't very helpful for writing servlets!

This should be exposed by the runtime component, I think: the library is currently marked for being exported.  And there must be something further required to index the jar as the classes aren't being found by content assist.