### PR TITLE
Fixes #373 - Honor cancel request from user during deploy

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,6 +32,12 @@ public class AppEngineProjectDeployerTest {
   public void testDeploy_NoAppEngineProjectVersion() throws CoreException {
     when(deployInfo.getProjectId()).thenReturn("fooProjectId");
     when(deployInfo.getProjectVersion()).thenReturn(null);
+    new AppEngineProjectDeployer(deployInfo).deploy(new Path("/non/existing/path"), cloudSdk, monitor);
+  }
+  
+  @Test(expected = OperationCanceledException.class)
+  public void testDeploy_cancelled() throws CoreException {
+    when(monitor.isCanceled()).thenReturn(true);
     new AppEngineProjectDeployer(deployInfo).deploy(new Path("/non/existing/path"), cloudSdk, monitor);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/ExplodedWarPublisherTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/ExplodedWarPublisherTest.java
@@ -1,26 +1,41 @@
 package com.google.cloud.tools.eclipse.appengine.deploy.standard;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ExplodedWarPublisherTest {
 
+  @Mock IProgressMonitor monitor;
+  
   @Test(expected = NullPointerException.class)
   public void testWriteProjectToStageDir_nullProject() throws CoreException {
-    new ExplodedWarPublisher().publish(null, null, null);
+    new ExplodedWarPublisher().publish(null, null, monitor);
   }
 
   @Test(expected = NullPointerException.class)
   public void testWriteProjectToStageDir_nullStagingDir() throws CoreException {
-    new ExplodedWarPublisher().publish(mock(IProject.class), null, null);
+    new ExplodedWarPublisher().publish(mock(IProject.class), null, monitor);
   }
   
   @Test(expected = IllegalArgumentException.class)
   public void testWriteProjectToStageDir_emptyStagingDir() throws CoreException {
-    new ExplodedWarPublisher().publish(mock(IProject.class), new Path(""), null);
+    new ExplodedWarPublisher().publish(mock(IProject.class), new Path(""), monitor);
+  }
+  
+  @Test(expected = OperationCanceledException.class)
+  public void testWriteProjectToStageDir_cancelled() throws CoreException {
+    when(monitor.isCanceled()).thenReturn(true);
+    new ExplodedWarPublisher().publish(mock(IProject.class), new Path(""), monitor);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardProjectStagingTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardProjectStagingTest.java
@@ -1,0 +1,29 @@
+package com.google.cloud.tools.eclipse.appengine.deploy.standard;
+
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StandardProjectStagingTest {
+
+  @Mock private IPath warDirectory;
+  @Mock private IPath stagingDirectory;
+  @Mock private CloudSdk cloudSdk;
+  @Mock private IProgressMonitor monitor;
+
+  @Test(expected = OperationCanceledException.class)
+  public void testStage_cancelled() {
+    when(monitor.isCanceled()).thenReturn(true);
+    new StandardProjectStaging().stage(warDirectory, stagingDirectory, cloudSdk, monitor);
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployer.java
@@ -7,6 +7,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 
@@ -40,6 +41,10 @@ public class AppEngineProjectDeployer {
   }
 
   public void deploy(IPath stagingDirectory, CloudSdk cloudSdk, IProgressMonitor monitor) throws CoreException {
+    if (monitor.isCanceled()) {
+      throw new OperationCanceledException();
+    }
+
     SubMonitor progress = SubMonitor.convert(monitor, 1);
     progress.setTaskName(Messages.getString("task.name.deploy.project")); //$NON-NLS-1$
     try  {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/ExplodedWarPublisher.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/ExplodedWarPublisher.java
@@ -4,6 +4,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jst.j2ee.internal.deployables.J2EEFlexProjDeployable;
 import org.eclipse.wst.common.componentcore.ComponentCore;
@@ -23,6 +24,9 @@ public class ExplodedWarPublisher {
    * exploded WAR.
    */
   public void publish(IProject project, IPath destination, IProgressMonitor monitor) throws CoreException {
+    if (monitor.isCanceled()) {
+      throw new OperationCanceledException();
+    }
     Preconditions.checkNotNull(project, "project is null"); //$NON-NLS-1$
     Preconditions.checkNotNull(destination, "destination is null"); //$NON-NLS-1$
     Preconditions.checkArgument(!destination.isEmpty(), "destination is empty path"); //$NON-NLS-1$

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardProjectStaging.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardProjectStaging.java
@@ -2,6 +2,7 @@ package com.google.cloud.tools.eclipse.appengine.deploy.standard;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.SubMonitor;
 
 import com.google.cloud.tools.appengine.api.deploy.DefaultStageStandardConfiguration;
@@ -20,6 +21,10 @@ public class StandardProjectStaging {
    * @param cloudSdk executes the staging operation
    */
   public void stage(IPath explodedWarDirectory, IPath stagingDir, CloudSdk cloudSdk, IProgressMonitor monitor) {
+    if (monitor.isCanceled()) {
+      throw new OperationCanceledException();
+    }
+
     SubMonitor progress = SubMonitor.convert(monitor, 1);
     progress.setTaskName(Messages.getString("task.name.stage.project")); //$NON-NLS-1$
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardProjectStaging.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardProjectStaging.java
@@ -17,7 +17,7 @@ public class StandardProjectStaging {
 
   /**
    * @param explodedWarDirectory the input of the staging operation
-   * @param stagingDirectory where the result of the staging operation will be written to
+   * @param stagingDirectory where the result of the staging operation will be written
    * @param cloudSdk executes the staging operation
    */
   public void stage(IPath explodedWarDirectory, IPath stagingDirectory, CloudSdk cloudSdk, IProgressMonitor monitor) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardProjectStaging.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardProjectStaging.java
@@ -17,10 +17,10 @@ public class StandardProjectStaging {
 
   /**
    * @param explodedWarDirectory the input of the staging operation
-   * @param stagingDir where the result of the staging operation will be written to
+   * @param stagingDirectory where the result of the staging operation will be written to
    * @param cloudSdk executes the staging operation
    */
-  public void stage(IPath explodedWarDirectory, IPath stagingDir, CloudSdk cloudSdk, IProgressMonitor monitor) {
+  public void stage(IPath explodedWarDirectory, IPath stagingDirectory, CloudSdk cloudSdk, IProgressMonitor monitor) {
     if (monitor.isCanceled()) {
       throw new OperationCanceledException();
     }
@@ -30,7 +30,7 @@ public class StandardProjectStaging {
 
     DefaultStageStandardConfiguration stagingConfig = new DefaultStageStandardConfiguration();
     stagingConfig.setSourceDirectory(explodedWarDirectory.toFile());
-    stagingConfig.setStagingDirectory(stagingDir.toFile());
+    stagingConfig.setStagingDirectory(stagingDirectory.toFile());
     stagingConfig.setEnableJarSplitting(true);
 
     CloudSdkAppEngineStandardStaging staging = new CloudSdkAppEngineStandardStaging(cloudSdk);


### PR DESCRIPTION
I was experimenting with cancellation for long running calls like deploy, but I believe rather the app-tools-lib should provide some hooks for this as this might be useful for other libraries building on top of app-tools-lib as well.