### PR TITLE
Regenerate .classpath files for .login and .login.tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/.classpath
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/.classpath
@@ -3,7 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="lib" path="/com.google.cloud.tools.eclipse.appengine.login/lib/google-api-client-1.22.0.jar"/>
-	<classpathentry kind="lib" path="/com.google.cloud.tools.eclipse.appengine.login/lib/google-oauth-client-1.22.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/.classpath
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/.classpath
@@ -4,8 +4,10 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="generated-sources"/>
-	<classpathentry kind="lib" path="lib/google-oauth-client-1.22.0.jar"/>
-	<classpathentry kind="lib" path="lib/google-api-client-1.22.0.jar"/>
-	<classpathentry kind="lib" path="lib/google-http-client-1.22.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/google-api-client-1.22.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/google-http-client-1.22.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/google-http-client-jackson2-1.22.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/google-oauth-client-1.22.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jackson-core-2.1.3.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
`com.google.cloud.tools.eclipse.appengine.login.tests` is pulling in two jars from `.login`, `google-api-client-1.22.0.jar` and `google-oauth-client-1.22.0.jar`, relating to OAuth.  `GoogleLoginServiceTest.java` is referencing `com.google.api.client.auth.oauth2.Credential`, whose definition references classes in `google-http-client-1.22.0.jar`:

```java
public class com.google.api.client.auth.oauth2.Credential implements 
    com.google.api.client.http.HttpExecuteInterceptor,
    com.google.api.client.http.HttpRequestInitializer,
    com.google.api.client.http.HttpUnsuccessfulResponseHandler {
```  

Because this jar is not in `.login.test`'s classpath, `GoogleLoginServiceTest` is generated with errors.

I used PDE's Regenerate Classpath and all is now well.