### PR TITLE
Enable server-side usage tracking

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
@@ -15,6 +15,7 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.eclipse.appengine.deploy.AppEngineProjectDeployer;
 import com.google.cloud.tools.eclipse.appengine.deploy.Messages;
 import com.google.cloud.tools.eclipse.sdk.ui.MessageConsoleWriterOutputLineListener;
+import com.google.cloud.tools.eclipse.util.CloudToolsInfo;
 import com.google.cloud.tools.eclipse.util.MessageConsoleUtilities;
 import com.google.common.base.Preconditions;
 
@@ -88,6 +89,8 @@ public class StandardDeployJob extends WorkspaceJob {
     CloudSdk cloudSdk = new CloudSdk.Builder()
                           .addStdOutLineListener(new MessageConsoleWriterOutputLineListener(outputStream))
                           .addStdErrLineListener(new MessageConsoleWriterOutputLineListener(outputStream))
+                          .appCommandMetricsEnvironment(CloudToolsInfo.TOOLS_NAME_FOR_METRICS)
+                          .appCommandMetricsEnvironmentVersion(CloudToolsInfo.getToolsVersion())
                           .build();
     return cloudSdk;
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
@@ -89,7 +89,7 @@ public class StandardDeployJob extends WorkspaceJob {
     CloudSdk cloudSdk = new CloudSdk.Builder()
                           .addStdOutLineListener(new MessageConsoleWriterOutputLineListener(outputStream))
                           .addStdErrLineListener(new MessageConsoleWriterOutputLineListener(outputStream))
-                          .appCommandMetricsEnvironment(CloudToolsInfo.TOOLS_NAME_FOR_METRICS)
+                          .appCommandMetricsEnvironment(CloudToolsInfo.METRICS_NAME)
                           .appCommandMetricsEnvironmentVersion(CloudToolsInfo.getToolsVersion())
                           .build();
     return cloudSdk;

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/META-INF/MANIFEST.MF
@@ -9,5 +9,6 @@ Export-Package: com.google.cloud.tools.eclipse.usagetracker
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.11.1",
  org.eclipse.jface,
  org.eclipse.ui.workbench,
- com.google.cloud.tools.eclipse.preferences
+ com.google.cloud.tools.eclipse.preferences,
+ com.google.cloud.tools.eclipse.util
 Import-Package: com.google.common.annotations

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -2,6 +2,7 @@ package com.google.cloud.tools.eclipse.usagetracker;
 
 import com.google.cloud.tools.eclipse.preferences.Activator;
 import com.google.cloud.tools.eclipse.preferences.AnalyticsPreferences;
+import com.google.cloud.tools.eclipse.util.CloudToolsInfo;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.eclipse.core.runtime.Platform;
@@ -36,9 +37,6 @@ public class AnalyticsPingManager {
   private static final String PREFERENCES_PLUGIN_ID = Activator.PLUGIN_ID;
 
   private static final String ANALYTICS_COLLECTION_URL = "https://ssl.google-analytics.com/collect";
-
-  // This name will be recorded as an originating app on Google Analytics.
-  private static final String APPLICATION_NAME = "gcloud-eclipse-tools";
 
   // Fixed-value query parameters present in every ping, and their fixed values:
   //
@@ -188,10 +186,10 @@ public class AnalyticsPingManager {
       String clientId, String eventName, String metadataKey, String metadataValue) {
     Map<String, String> parametersMap = new HashMap<>(STANDARD_PARAMETERS);
     parametersMap.put("cid", clientId);
-    parametersMap.put("cd19", APPLICATION_NAME);  // cd19: "event type"
+    parametersMap.put("cd19", CloudToolsInfo.TOOLS_NAME_FOR_METRICS);  // cd19: "event type"
     parametersMap.put("cd20", eventName);
 
-    String virtualPageUrl = "/virtual/" + APPLICATION_NAME + "/" + eventName;
+    String virtualPageUrl = "/virtual/" + CloudToolsInfo.TOOLS_NAME_FOR_METRICS + "/" + eventName;
     parametersMap.put("dp", virtualPageUrl);
     parametersMap.put("dh", "virtual.eclipse");
 

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -186,10 +186,10 @@ public class AnalyticsPingManager {
       String clientId, String eventName, String metadataKey, String metadataValue) {
     Map<String, String> parametersMap = new HashMap<>(STANDARD_PARAMETERS);
     parametersMap.put("cid", clientId);
-    parametersMap.put("cd19", CloudToolsInfo.TOOLS_NAME_FOR_METRICS);  // cd19: "event type"
+    parametersMap.put("cd19", CloudToolsInfo.METRICS_NAME);  // cd19: "event type"
     parametersMap.put("cd20", eventName);
 
-    String virtualPageUrl = "/virtual/" + CloudToolsInfo.TOOLS_NAME_FOR_METRICS + "/" + eventName;
+    String virtualPageUrl = "/virtual/" + CloudToolsInfo.METRICS_NAME + "/" + eventName;
     parametersMap.put("dp", virtualPageUrl);
     parametersMap.put("dh", "virtual.eclipse");
 

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/CloudToolsInfoTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/CloudToolsInfoTest.java
@@ -15,18 +15,13 @@
 
 package com.google.cloud.tools.eclipse.util;
 
-import org.osgi.framework.FrameworkUtil;
+import org.junit.Assert;
+import org.junit.Test;
 
-/**
- * Provides generic information about the plug-in, such as a name to be used for usage
- * reporting and the current version, etc.
- */
-public class CloudToolsInfo {
+public class CloudToolsInfoTest {
 
-  // Don't change the value; this name is used as an originating "application" of usage metrics.
-  public static String METRICS_NAME = "gcloud-eclipse-tools";
-
-  public static String getToolsVersion() {
-    return FrameworkUtil.getBundle(new CloudToolsInfo().getClass()).getVersion().toString();
+  @Test
+  public void testGetToolsVersion() {
+    Assert.assertTrue(CloudToolsInfo.getToolsVersion().startsWith("0.1.0."));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/CloudToolsInfo.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/CloudToolsInfo.java
@@ -1,0 +1,17 @@
+package com.google.cloud.tools.eclipse.util;
+
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * Provides generic information about our collective tools, such as a name to be used for usage
+ * reporting and the current version, etc.
+ */
+public class CloudToolsInfo {
+  
+  // Don't change the value; this name is used as an originating "application" of usage metrics.
+  public static String TOOLS_NAME_FOR_METRICS = "gcloud-eclipse-tools";
+
+  public static String getToolsVersion() {
+    return FrameworkUtil.getBundle(new CloudToolsInfo().getClass()).getVersion().toString();
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/CloudToolsInfo.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/CloudToolsInfo.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
 package com.google.cloud.tools.eclipse.util;
 
 import org.osgi.framework.FrameworkUtil;
@@ -7,7 +22,7 @@ import org.osgi.framework.FrameworkUtil;
  * reporting and the current version, etc.
  */
 public class CloudToolsInfo {
-  
+
   // Don't change the value; this name is used as an originating "application" of usage metrics.
   public static String TOOLS_NAME_FOR_METRICS = "gcloud-eclipse-tools";
 


### PR DESCRIPTION
Fixes #137.

I believe, for now, there is only one place in code that requires setting these constants when creating a `CloudSdk` instance for server interaction.

I created a new `CloudToolsInfo` class under `.util`. Let me know if you have better suggestions or better names.

FYI, `getToolsVersion()` currently returns `0.1.0.qualifier`.

