### PR TITLE
Fix issues with debug launches for App Engine Standard apps

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -139,6 +139,8 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
     // Create run configuration
     DefaultRunConfiguration devServerRunConfiguration = new DefaultRunConfiguration();
     devServerRunConfiguration.setAppYamls(runnables);
+    // we can only connect with a single JVM
+    devServerRunConfiguration.setMaxModuleInstances(1);
 
     List<String> jvmFlags = new ArrayList<String>();
     // FIXME: workaround bug when running on a Java8 JVM

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -12,6 +12,7 @@ import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jdt.launching.AbstractJavaLaunchConfigurationDelegate;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.IVMConnector;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.SocketUtil;
@@ -27,6 +28,7 @@ import java.util.Map;
 
 public class LocalAppEngineServerLaunchConfigurationDelegate
     extends AbstractJavaLaunchConfigurationDelegate {
+
   private static final String DEBUGGER_HOST = "localhost";
 
   @Override
@@ -42,6 +44,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     }
 
     // App Engine dev server can only debug one module at a time
+    // as we cannot configure the IVMConnector to continue listening
     if (mode.equals(ILaunchManager.DEBUG_MODE) && modules.length > 1) {
       String message = "The App Engine development server supports only 1 module when running in debug mode";
       Status status = new Status(IStatus.ERROR, Activator.PLUGIN_ID, message);
@@ -63,29 +66,23 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
 
     setDefaultSourceLocator(launch, configuration);
 
-    LocalAppEngineServerDelegate serverDelegate = LocalAppEngineServerDelegate.getAppEngineServer(server);
-    int debugPort = -1;
     if (ILaunchManager.DEBUG_MODE.equals(mode)) {
-      debugPort = getDebugPort();
-
-      try {
-        setupDebugTarget(launch, configuration, serverDelegate, modules[0].getProject().getName(),
-            debugPort, monitor);
-      } catch (CoreException e) {
-        Activator.logError(e);
-      }
-    }
-
-    // Start server
-    if (mode.equals(ILaunchManager.DEBUG_MODE)) {
+      int debugPort = getDebugPort();
+      setupDebugTarget(launch, configuration, debugPort, monitor);
       serverBehaviour.startDebugDevServer(runnables, console.newMessageStream(), debugPort);
     } else {
       serverBehaviour.startDevServer(runnables, console.newMessageStream());
     }
   }
 
-  private void setupDebugTarget(ILaunch launch, ILaunchConfiguration configuration, LocalAppEngineServerDelegate serverDelegate, String projectName, int port, IProgressMonitor monitor)
-      throws CoreException {
+  private void setupDebugTarget(ILaunch launch, ILaunchConfiguration configuration, int port,
+      IProgressMonitor monitor) throws CoreException {
+    IVMConnector connector =
+        JavaRuntime.getVMConnector(IJavaLaunchConfigurationConstants.ID_SOCKET_LISTEN_VM_CONNECTOR);
+    if (connector == null) {
+      abort("Cannot find Socket Listening connector", null, 0);
+      return; // keep JDT null analysis happy
+    }
 
     // Set JVM debugger connection parameters
     int timeout = JavaRuntime.getPreferences().getInt(JavaRuntime.PREF_CONNECT_TIMEOUT);
@@ -93,13 +90,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     connectionParameters.put("hostname", DEBUGGER_HOST);
     connectionParameters.put("port", Integer.toString(port));
     connectionParameters.put("timeout", Integer.toString(timeout));
-    
-    IVMConnector connector = JavaRuntime.getVMConnector("org.eclipse.jdt.launching.socketListenConnector");
-    if(connector == null) {
-      abort("Cannot find Socket Listening connector", null, 0);
-    } else {
-      connector.connect(connectionParameters, monitor, launch);
-    }
+    connector.connect(connectionParameters, monitor, launch);
   }
 
 


### PR DESCRIPTION
Fixes #433 

Changes our launch delegate to connect to remote JVM directly rather than creating and running a new remote launch configuration, as launch configurations are independent and are shown in the _Debug_ view.  This change ensures the remote JVM is brought under the AppEngine launch configuration.  

Fixes #473

Launches `dev_appserver` with `—max_module_instances 1` to prevent subsequent JVMs crashing trying to connect to the debugger.