### PR TITLE
Fixes #482 - Cannot deploy

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/util/ProjectFromSelectionHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/util/ProjectFromSelectionHelper.java
@@ -4,6 +4,7 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.handlers.HandlerUtil;
@@ -21,8 +22,16 @@ public class ProjectFromSelectionHelper {
     ISelection selection = HandlerUtil.getCurrentSelectionChecked(event);
     if (selection instanceof IStructuredSelection) {
       IStructuredSelection structuredSelection = (IStructuredSelection) selection;
-      if (structuredSelection.size() == 1 && structuredSelection.getFirstElement() instanceof IProject) {
-        IProject project = (IProject) structuredSelection.getFirstElement();
+      if (structuredSelection.size() == 1) {
+        IProject project;
+        if (structuredSelection.getFirstElement() instanceof IProject) {
+          project = (IProject) structuredSelection.getFirstElement();
+        } else if (structuredSelection.getFirstElement() instanceof IJavaProject) {
+          project = ((IJavaProject) structuredSelection.getFirstElement()).getProject();
+        } else {
+          return null;
+        }
+
         IFacetedProject facetedProject = facetedProjectHelper.getFacetedProject(project);
         // TODO replace with constant from AppEngineFacet (after possibly relocating that class)
         if (facetedProjectHelper.projectHasFacet(facetedProject, "com.google.cloud.tools.eclipse.appengine.facet")) {


### PR DESCRIPTION
When user runs the deploy command the type of the selection depends on the current ~~perspective~~ explorer (e.g. Project Explorer (default in Java EE perspective) vs Package Explorer (default in Java perspective). If it is ~~Java~~ Package Explorer, then the selection will be an IJavaProject otherwise an IProject.