### PR TITLE
Fix indirect class references issues in com.google.cloud.tools.eclipse.appengine.deploy

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/build.properties
@@ -6,3 +6,5 @@ bin.includes = META-INF/,\
                plugin.properties
 javacSource=1.7
 javacTarget=1.7               
+additional.bundles = org.eclipse.jst.server.core, org.eclipse.wst.web
+


### PR DESCRIPTION
I see errors in c.g.c.t.e.appengine.deploy in _ExplodedWarPublisher.java_
  - The type `org.eclipse.wst.web.internal.deployables.FlatComponentDeployable` cannot be resolved. It is indirectly referenced from required .class files
  - The type `org.eclipse.jst.server.core.IWebFragmentModule` cannot be resolved. It is indirectly referenced from required .class files

This patch adds compile-time dependencies on org.eclipse.wst.web (for `org.eclipse.wst.web.internal.deployables.FlatComponentDeployable`) and 
`org.eclipse.jst.server.core` (for `org.eclipse.jst.server.core.IWebFragmentModule`).  And it fixed indentation in the `Require-Bundle` too.