### PR TITLE
Include usagetracker plugin to e45 feature

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
@@ -117,6 +117,13 @@
          unpack="false"/>
 
   <plugin
+         id="com.google.cloud.tools.eclipse.usagetracker"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+  <plugin
          id="com.google.cloud.tools.eclipse.util"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
I'm sure we will need this.

BTW, is it correct that `com.google.cloud.tools.app.lib` is in both `e45` and `3rdparty`?