### PR TITLE
Avoid failures in integration tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
@@ -108,8 +108,8 @@ public class SwtBotAppEngineActions {
       bot.list().select(archetypeDescription);
     }
 
-    int mavenCompletionTimeoutSeconds = 15000; // can take a loooong time
-    SwtBotTimeoutManager.setTimeout(mavenCompletionTimeoutSeconds);
+    int mavenCompletionTimeout = 45000/* ms */; // can take a loooong time to fetch archetypes
+    SwtBotTimeoutManager.setTimeout(mavenCompletionTimeout);
     SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Finish"));
     SwtBotTimeoutManager.resetTimeout();
     // this isn't right for location != null

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
           <artifactId>tycho-surefire-plugin</artifactId>
           <version>${tycho.version}</version>
           <configuration>
-            <argLine>-Dorg.eclipse.swtbot.search.timeout=${org.eclipse.swtbot.search.timeout} -Xms40m -Xmx1G ${os-jvm-flags}</argLine>
+            <argLine>-Dorg.eclipse.swtbot.search.timeout=${org.eclipse.swtbot.search.timeout} -Xms40m -Xmx1G -XX:MaxPermSize=512m ${os-jvm-flags}</argLine>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
Bump maximum `PermGen` settings for Java 7 to avoid OOMEs.
Increase Maven archetype-installation timeout from 15000ms to 45000ms.