### PR TITLE
Inform to sign in for deploy if not signed in

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/messages.properties
@@ -10,5 +10,6 @@ deploy.standard.runnable.name=Deploying to App Engine Standard
 deploy.job.stagingdir.create.failed=Cannot create staging directory.
 deploy.job.sourcedir.missing=Staging source directory does not exist.
 deploy.failed.error.message=Deploy failed.
-login.failed=Login failed.
 save.credential.failed=Saving credential to file failed.
+prompt.login.dialog.title=Sign-in Required for Deploying
+prompt.login.dialog.message=Do you want to sign in to authorize deploying to the target project?

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/messages.properties
@@ -12,4 +12,4 @@ deploy.job.sourcedir.missing=Staging source directory does not exist.
 deploy.failed.error.message=Deploy failed.
 save.credential.failed=Saving credential to file failed.
 prompt.login.dialog.title=Sign-in Required for Deploying
-prompt.login.dialog.message=Do you want to sign in to authorize deploying to the target project?
+prompt.login.dialog.message=To deploy, please sign in using an external browser.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/messages.properties
@@ -11,5 +11,4 @@ deploy.job.stagingdir.create.failed=Cannot create staging directory.
 deploy.job.sourcedir.missing=Staging source directory does not exist.
 deploy.failed.error.message=Deploy failed.
 save.credential.failed=Saving credential to file failed.
-prompt.login.dialog.title=Sign-in Required for Deploying
-prompt.login.dialog.message=To deploy, please sign in using an external browser.
+deploy.login.dialog.message=Browser opened to authorize deployment.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployCommandHandler.java
@@ -115,7 +115,7 @@ public class StandardDeployCommandHandler extends AbstractHandler {
     if (MessageDialog.openQuestion(HandlerUtil.getActiveShell(event),
         Messages.getString("prompt.login.dialog.title"),
         Messages.getString("prompt.login.dialog.message"))) {
-      // GoogleLoginService takes care of displaying error messages; so no need to check errors.
+      // GoogleLoginService takes care of displaying error messages; no need to check errors.
       return loginService.getActiveCredential();
     }
     return null;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployCommandHandler.java
@@ -34,8 +34,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
-import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.ui.handlers.HandlerUtil;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -112,17 +110,8 @@ public class StandardDeployCommandHandler extends AbstractHandler {
       return credential;
     }
 
-    new MessageDialog(HandlerUtil.getActiveShell(event),
-                      Messages.getString("prompt.login.dialog.title"),
-                      null /* no image */,
-                      Messages.getString("prompt.login.dialog.message"),
-                      MessageDialog.INFORMATION,
-                      new String[]{ "Launch Browser" },
-                      0 /* default button index */)
-        .open();
-
     // GoogleLoginService takes care of displaying error messages; no need to check errors.
-    return loginService.getActiveCredential();
+    return loginService.getActiveCredential(Messages.getString("deploy.login.dialog.message"));
   }
 
   private void launchCleanupJob() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployCommandHandler.java
@@ -112,13 +112,17 @@ public class StandardDeployCommandHandler extends AbstractHandler {
       return credential;
     }
 
-    if (MessageDialog.openQuestion(HandlerUtil.getActiveShell(event),
-        Messages.getString("prompt.login.dialog.title"),
-        Messages.getString("prompt.login.dialog.message"))) {
-      // GoogleLoginService takes care of displaying error messages; no need to check errors.
-      return loginService.getActiveCredential();
-    }
-    return null;
+    new MessageDialog(HandlerUtil.getActiveShell(event),
+                      Messages.getString("prompt.login.dialog.title"),
+                      null /* no image */,
+                      Messages.getString("prompt.login.dialog.message"),
+                      MessageDialog.INFORMATION,
+                      new String[]{ "Launch Browser" },
+                      0 /* default button index */)
+        .open();
+
+    // GoogleLoginService takes care of displaying error messages; no need to check errors.
+    return loginService.getActiveCredential();
   }
 
   private void launchCleanupJob() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginCommandHandler.java
@@ -21,7 +21,7 @@ public class GoogleLoginCommandHandler extends AbstractHandler implements IEleme
 
     Credential credential = loginService.getCachedActiveCredential();  // See if already logged in.
     if (credential == null) {
-      loginService.getActiveCredential();  // Log in.
+      loginService.getActiveCredential(null /* no custom dialog message */);  // Log in.
     } else {
       if (MessageDialog.openConfirm(HandlerUtil.getActiveShell(event),
           Messages.LOGOUT_CONFIRM_DIALOG_TITILE, Messages.LOGOUT_CONFIRM_DIALOG_MESSAGE)) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/GoogleLoginService.java
@@ -105,7 +105,7 @@ public class GoogleLoginService implements IGoogleLoginService {
   }
 
   @Override
-  public Credential getActiveCredential() {
+  public Credential getActiveCredential(String dialogMessage) {
     if (!loginInProgress.compareAndSet(false, true)) {
       loginServiceUi.showErrorDialogHelper(
           Messages.LOGIN_ERROR_DIALOG_TITLE, Messages.LOGIN_ERROR_IN_PROGRESS);
@@ -118,7 +118,7 @@ public class GoogleLoginService implements IGoogleLoginService {
     // conservatively if login seems to be in progress.
     try {
       synchronized (loginState) {
-        if (loginState.logInWithLocalServer(null /* parameter ignored */)) {
+        if (loginState.logInWithLocalServer(dialogMessage)) {
           return loginState.getCredential();
         }
         return null;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/IGoogleLoginService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/IGoogleLoginService.java
@@ -27,8 +27,10 @@ public interface IGoogleLoginService {
    * operation and display a general message that login is required but was cancelled or failed.
    *
    * Must be called from a UI context.
+   *
+   * @param dialogMessage custom login dialog message. Can be null
    */
-  public Credential getActiveCredential();
+  public Credential getActiveCredential(String dialogMessage);
 
   /**
    * Returns the credential of an active user (among multiple logged-in users). Unlike {@link

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/LoginServiceUi.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/LoginServiceUi.java
@@ -91,7 +91,7 @@ public class LoginServiceUi implements UiFacade {
   }
 
   @Override
-  public VerificationCodeHolder obtainVerificationCodeFromExternalUserInteraction(String title) {
+  public VerificationCodeHolder obtainVerificationCodeFromExternalUserInteraction(String message) {
     LocalServerReceiver codeReceiver = new LocalServerReceiver();
 
     try {
@@ -102,7 +102,8 @@ public class LoginServiceUi implements UiFacade {
         return null;
       }
 
-      String authorizationCode = showProgressDialogAndWaitForCode(codeReceiver, redirectUrl);
+      String authorizationCode = showProgressDialogAndWaitForCode(
+          message, codeReceiver, redirectUrl);
       if (authorizationCode != null) {
         return new VerificationCodeHolder(authorizationCode, redirectUrl);
       }
@@ -118,7 +119,7 @@ public class LoginServiceUi implements UiFacade {
     }
   }
 
-  private String showProgressDialogAndWaitForCode(
+  private String showProgressDialogAndWaitForCode(final String message,
       final LocalServerReceiver codeReceiver, final String redirectUrl) throws IOException {
     try {
       final String[] codeHolder = new String[1];
@@ -140,7 +141,8 @@ public class LoginServiceUi implements UiFacade {
         @Override
         public void run(IProgressMonitor monitor)
             throws InvocationTargetException, InterruptedException {
-          monitor.beginTask(Messages.LOGIN_PROGRESS_DIALOG_MESSAGE, IProgressMonitor.UNKNOWN);
+          monitor.beginTask(message != null ? message : Messages.LOGIN_PROGRESS_DIALOG_MESSAGE,
+              IProgressMonitor.UNKNOWN);
           // Fork another sub-job to circumvent the limitation of LocalServerReceiver.
           // (See the comments of scheduleCodeWaitingJob().)
           scheduleCodeWaitingJob(


### PR DESCRIPTION
Fixes #472 #524.

![prompt-login-for-deploy](https://cloud.githubusercontent.com/assets/10523105/17706630/cd6bd186-63aa-11e6-8f84-c00038b548eb.png)

Moved out `login()` from `launchDeployJob()`, since `launchDeployJob()` sounds like it will launch a job no matter what.

Did some tests: cancel login, deny authorization, deploy while logged in, etc.

