### PR TITLE
Add integration test for launching native App Engine Standard project

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/META-INF/MANIFEST.MF
@@ -19,3 +19,5 @@ Require-Bundle: com.google.cloud.tools.eclipse.swtbot,
  org.eclipse.swtbot.swt.finder;bundle-version="2.3.0",
  org.eclipse.swt;bundle-version="3.104.2",
  org.eclipse.wst.common.project.facet.core
+Import-Package: org.eclipse.core.runtime.preferences,
+ org.osgi.service.prefs;version="1.1.1"

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProject.java
@@ -103,17 +103,16 @@ public class DebugNativeAppEngineStandardProject extends AbstractProjectTests {
         "Starting module \"default\" running at: http://localhost:8080", consoleContents);
 
     assertEquals("Hello App Engine!",
-        getUrlContents(new URL("http://localhost:8080/hello"), SWTBotPreferences.TIMEOUT));
+        getUrlContents(new URL("http://localhost:8080/hello"), (int) SWTBotPreferences.TIMEOUT));
 
-    for (SWTBotToolbarButton b : consoleView.getToolbarButtons()) {
-      if ("Stop the server".equals(b.getToolTipText())) {
-        b.click();
+    for (SWTBotToolbarButton button : consoleView.getToolbarButtons()) {
+      if ("Stop the server".equals(button.getToolTipText())) {
+        button.click();
       }
     }
     SwtBotTreeUtilities.waitUntilTreeContainsText(bot, allItems[0], "<terminated>");
     assertNoService(new URL("http://localhost:8080/hello"));
   }
-
 
   /**
    * Check that there is no remote service for the URL.
@@ -133,17 +132,17 @@ public class DebugNativeAppEngineStandardProject extends AbstractProjectTests {
    * 
    * @throws IOException if cannot connect or timeout
    */
-  private String getUrlContents(URL url, long timeoutInMilliseconds) throws IOException {
+  private String getUrlContents(URL url, int timeoutInMilliseconds) throws IOException {
     StringBuilder content = new StringBuilder();
     URLConnection conn = url.openConnection();
-    conn.setConnectTimeout(5); // ms
-    conn.setReadTimeout((int) timeoutInMilliseconds); // ms
+    conn.setConnectTimeout(100); // ms
+    conn.setReadTimeout(timeoutInMilliseconds); // ms
     try (InputStreamReader reader =
         new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8)) {
       char[] buf = new char[1024];
-      int rc;
-      while ((rc = reader.read(buf)) > 0) {
-        content.append(buf, 0, rc);
+      int length;
+      while ((length = reader.read(buf)) >= 0) {
+        content.append(buf, 0, length);
       }
     }
     return content.toString().trim();

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProject.java
@@ -58,6 +58,7 @@ public class DebugNativeAppEngineStandardProject extends AbstractProjectTests {
    */
   @Test
   public void testDebugLaunch() throws Exception {
+    // Disable WTP's download-server-bindings
     // Equivalent to: ServerUIPreferences.getInstance().setCacheFrequency(0);
     Preferences prefs = InstanceScope.INSTANCE.getNode("org.eclipse.wst.server.ui");
     prefs.putInt("cache-frequency", 0);

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProject.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.integration.appengine;
+
+import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.widgetOfType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.tools.eclipse.swtbot.SwtBotProjectActions;
+import com.google.cloud.tools.eclipse.swtbot.SwtBotTestingUtilities;
+import com.google.cloud.tools.eclipse.swtbot.SwtBotTreeUtilities;
+
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarButton;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.service.prefs.Preferences;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Create a native App Engine Standard project, launch in debug mode, verify working, and then
+ * terminate.
+ */
+@RunWith(SWTBotJunit4ClassRunner.class)
+public class DebugNativeAppEngineStandardProject extends AbstractProjectTests {
+  /**
+   * Launch a native application in debug mode and verify that (1) it started, (2) it can be
+   * terminated and removed from the launch list, and (3) the process is actually terminated
+   */
+  @Test
+  public void testDebugLaunch() throws Exception {
+    // Equivalent to: ServerUIPreferences.getInstance().setCacheFrequency(0);
+    Preferences prefs = InstanceScope.INSTANCE.getNode("org.eclipse.wst.server.ui");
+    prefs.putInt("cache-frequency", 0);
+    prefs.sync();
+
+    assertNoService(new URL("http://localhost:8080/hello"));
+
+    project = SwtBotAppEngineActions.createNativeWebAppProject(bot, "testapp", null,
+        "app.engine.test", "my-project-id");
+    assertTrue(project.exists());
+
+    SWTBotTreeItem project = SwtBotProjectActions.selectProject(bot, "testapp");
+    assertNotNull(project);
+    SwtBotTestingUtilities.performAndWaitForWindowChange(bot, new Runnable() {
+      @Override
+      public void run() {
+        bot.menu("Run").menu("Debug As").menu("1 Debug on Server").click();
+      }
+    });
+
+    SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Finish"));
+
+    bot.perspectiveById("org.eclipse.debug.ui.DebugPerspective").activate(); // IDebugUIConstants.ID_DEBUG_PERSPECTIVE
+    SWTBotView debugView = bot.viewById("org.eclipse.debug.ui.DebugView"); // IDebugUIConstants.ID_DEBUG_VIEW
+    debugView.show();
+
+    SWTBotTree launchTree =
+        new SWTBotTree(bot.widget(widgetOfType(Tree.class), debugView.getWidget()));
+     SwtBotTreeUtilities.waitUntilTreeHasItems(bot, launchTree);
+    SWTBotTreeItem[] allItems = launchTree.getAllItems();
+    SwtBotTreeUtilities.waitUntilTreeHasText(bot, allItems[0]);
+    assertTrue("No App Engine launch found",
+        allItems[0].getText().contains("App Engine Standard at localhost"));
+
+    SWTBotView consoleView = bot.viewById("org.eclipse.ui.console.ConsoleView"); // IConsoleConstants.ID_CONSOLE_VIEW
+    consoleView.show();
+    assertTrue("App Engine console not active", consoleView.getViewReference()
+        .getContentDescription().contains("App Engine Standard at localhost"));
+    final SWTBotStyledText consoleContents =
+        new SWTBotStyledText(bot.widget(widgetOfType(StyledText.class), consoleView.getWidget()));
+    SwtBotTestingUtilities.waitUntilStyledTextContains(bot,
+        "Starting module \"default\" running at: http://localhost:8080", consoleContents);
+
+    assertEquals("Hello App Engine!",
+        getUrlContents(new URL("http://localhost:8080/hello"), SWTBotPreferences.TIMEOUT));
+
+    for (SWTBotToolbarButton b : consoleView.getToolbarButtons()) {
+      if ("Stop the server".equals(b.getToolTipText())) {
+        b.click();
+      }
+    }
+    SwtBotTreeUtilities.waitUntilTreeContainsText(bot, allItems[0], "<terminated>");
+    assertNoService(new URL("http://localhost:8080/hello"));
+  }
+
+
+  /**
+   * Check that there is no remote service for the URL.
+   */
+  private void assertNoService(URL url) {
+    try {
+      getUrlContents(url, 10);
+      fail("There appears to be life at " + url);
+    } catch (IOException ex) {
+      /* expected */
+    }
+  }
+
+
+  /**
+   * Read the content as a string from the specified URL.
+   * 
+   * @throws IOException if cannot connect or timeout
+   */
+  private String getUrlContents(URL url, long timeoutInMilliseconds) throws IOException {
+    StringBuilder content = new StringBuilder();
+    URLConnection conn = url.openConnection();
+    conn.setConnectTimeout(5); // ms
+    conn.setReadTimeout((int) timeoutInMilliseconds); // ms
+    try (InputStreamReader reader =
+        new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8)) {
+      char[] buf = new char[1024];
+      int rc;
+      while ((rc = reader.read(buf)) > 0) {
+        content.append(buf, 0, rc);
+      }
+    }
+    return content.toString().trim();
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTestingUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTestingUtilities.java
@@ -22,6 +22,7 @@ import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 
 /**
@@ -106,6 +107,24 @@ public class SwtBotTestingUtilities {
       @Override
       public boolean test() throws Exception {
         return !shell.isActive();
+      }
+    });
+  }
+
+  /**
+   * Wait until the given text widget contains the provided string
+   */
+  public static void waitUntilStyledTextContains(SWTBot bot, final String text,
+      final SWTBotStyledText widget) {
+    bot.waitUntil(new DefaultCondition() {
+      @Override
+      public boolean test() throws Exception {
+        return widget.getText().contains(text);
+      }
+
+      @Override
+      public String getFailureMessage() {
+        return "Text not found!";
       }
     });
   }

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.eclipse.swtbot;
 
 import org.eclipse.swt.widgets.TreeItem;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
@@ -314,6 +315,44 @@ public class SwtBotTreeUtilities {
           }
         }
         return null;
+      }
+    });
+  }
+
+  /**
+   * Wait until the given tree has items, and return the first item.
+   * 
+   * @throws TimeoutException if no items appear within the default timeout
+   */
+  public static SWTBotTreeItem waitUntilTreeHasItems(SWTWorkbenchBot bot, final SWTBotTree tree) {
+    bot.waitUntil(new DefaultCondition() {
+      @Override
+      public String getFailureMessage() {
+        return "Tree items never appeared";
+      }
+
+      @Override
+      public boolean test() throws Exception {
+        return tree.hasItems();
+      }
+    });
+    return tree.getAllItems()[0];
+  }
+
+  /**
+   * Wait until the tree item contains the given text
+   */
+  public static void waitUntilTreeContainsText(SWTWorkbenchBot bot, final SWTBotTreeItem treeItem,
+      final String text) {
+    bot.waitUntil(new DefaultCondition() {
+      @Override
+      public boolean test() throws Exception {
+        return treeItem.getText().contains(text);
+      }
+
+      @Override
+      public String getFailureMessage() {
+        return "Text never appeared";
       }
     });
   }


### PR DESCRIPTION
Adds a new test that:
  - creates a native App Engine Standard project
  - launches in debug mode
  - verifies that the app is running
  - terminates the app and verifies is no longer accessible

Fixes #560 