### PR TITLE
Do not set default source locator

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -69,8 +69,6 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     console.clearConsole();
     console.activate();
 
-    setDefaultSourceLocator(launch, configuration);
-
     if (ILaunchManager.DEBUG_MODE.equals(mode)) {
       int debugPort = getDebugPort();
       setupDebugTarget(launch, configuration, debugPort, monitor);


### PR DESCRIPTION
My change that added a default source locator breaks the source locating.

Steps to repeat:
  - create new native App Engine Standard project
  - set a breakpoint in HelloAppEngine's `doGet`
  - launch under debugger and open `http://localhost:8080/hello` to get into debugger

Notice that source is not found without this patch.

Fixes #575