### PR TITLE
Wait for pending jobs on project creation

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewMavenBasedAppEngineProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewMavenBasedAppEngineProjectWizardTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.integration.appengine;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
@@ -99,6 +100,7 @@ public class NewMavenBasedAppEngineProjectWizardTest extends AbstractProjectTest
     assertTrue(project.exists());
 
     IFacetedProject facetedProject = new FacetedProjectHelper().getFacetedProject(project);
+    assertNotNull("m2e-wtp should create a faceted project", facetedProject);
     assertTrue(
         new FacetedProjectHelper().projectHasFacet(facetedProject, AppEngineStandardFacet.ID));
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.integration.appengine;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -75,6 +76,7 @@ public class NewNativeAppEngineStandardProjectTest extends AbstractProjectTests 
     assertTrue(project.exists());
 
     IFacetedProject facetedProject = new FacetedProjectHelper().getFacetedProject(project);
+    assertNotNull("Native App Engine projects are faceted", facetedProject);
     assertTrue(
         new FacetedProjectHelper().projectHasFacet(facetedProject, AppEngineStandardFacet.ID));
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
@@ -76,7 +76,7 @@ public class NewNativeAppEngineStandardProjectTest extends AbstractProjectTests 
     assertTrue(project.exists());
 
     IFacetedProject facetedProject = new FacetedProjectHelper().getFacetedProject(project);
-    assertNotNull("Native App Engine projects are faceted", facetedProject);
+    assertNotNull("Native App Engine projects should be faceted", facetedProject);
     assertTrue(
         new FacetedProjectHelper().projectHasFacet(facetedProject, AppEngineStandardFacet.ID));
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.eclipse.integration.appengine;
 import com.google.cloud.tools.eclipse.appengine.deploy.AppEngineDeployInfo;
 import com.google.cloud.tools.eclipse.swtbot.SwtBotTestingUtilities;
 import com.google.cloud.tools.eclipse.swtbot.SwtBotTimeoutManager;
+import com.google.cloud.tools.eclipse.swtbot.SwtBotWorkbenchActions;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -74,6 +75,7 @@ public class SwtBotAppEngineActions {
       bot.textWithLabel("App Engine Project ID: (optional)").setText(projectId);
     }
     SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Finish"));
+    SwtBotWorkbenchActions.waitForIdle(bot);
     return waitUntilProjectExists(bot, getWorkspaceRoot().getProject(projectName));
   }
 
@@ -114,6 +116,7 @@ public class SwtBotAppEngineActions {
     SwtBotTimeoutManager.setTimeout(mavenCompletionTimeout);
     SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Finish"));
     SwtBotTimeoutManager.resetTimeout();
+    SwtBotWorkbenchActions.waitForIdle(bot);
     return waitUntilProjectExists(bot, getWorkspaceRoot().getProject(artifactId));
   }
 


### PR DESCRIPTION
Add calls to `SwtBotWorkbenchActions.waitForIdle(bot)`.
```
testHelloWorld(com.google.cloud.tools.eclipse.integration.appengine.NewMavenBasedAppEngineProjectWizardTest)  Time elapsed: 5.78 sec  <<< ERROR!
java.lang.NullPointerException: facetedProject is null
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:229)
	at com.google.cloud.tools.eclipse.util.FacetedProjectHelper.projectHasFacet(FacetedProjectHelper.java:31)
	at com.google.cloud.tools.eclipse.integration.appengine.NewMavenBasedAppEngineProjectWizardTest.createAndCheck(NewMavenBasedAppEngineProjectWizardTest.java:103)
	at com.google.cloud.tools.eclipse.integration.appengine.NewMavenBasedAppEngineProjectWizardTest.testHelloWorld(NewMavenBasedAppEngineProjectWizardTest.java:51)
```