### PR TITLE
Release lock first when a user cancels login

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/LoginServiceUi.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/LoginServiceUi.java
@@ -137,8 +137,8 @@ public class LoginServiceUi implements UiFacade {
         }
         @Override
         protected void cancelPressed() {
-          stopCodeWaitingJob(redirectUrl);
           wait.release();  // Allow termination of the attached task.
+          stopCodeWaitingJob(redirectUrl);
 
           AnalyticsPingManager.getInstance().sendPing(
               AnalyticsEvents.LOGIN_CANCELED, null, null, getParentShell());


### PR DESCRIPTION
When a user cancels login, we release a lock which terminates the dialog task and closes the dialog.

I think it's a better idea to release the lock first, since we shouldn't assume `stopCodeWaitingJob()` will throw an unchecked exception.